### PR TITLE
Fix encoding issue

### DIFF
--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -22,13 +22,13 @@ class CustomCSSExtension extends Minz_Extension {
 		$filepath = join_path($this->getPath(), 'static', $filename);
 
 		if (Minz_Request::isPost()) {
-			$css_rules = Minz_Request::param('css-rules', '');
+			$css_rules = html_entity_decode(Minz_Request::param('css-rules', ''));
 			file_put_contents($filepath, $css_rules);
 		}
 
 		$this->css_rules = '';
 		if (file_exists($filepath)) {
-			$this->css_rules = file_get_contents($filepath);
+			$this->css_rules = htmlentities(file_get_contents($filepath));
 		}
 	}
 }


### PR DESCRIPTION
Otherwise you wouldn't be able to use selectors like `>` and anything else that'd result in invalid CSS.

Probably fixes https://github.com/FreshRSS/FreshRSS/issues/959 (see comment https://github.com/FreshRSS/FreshRSS/issues/959#issuecomment-134328259) but without having the full CSS used by @Kirill that can't be tested.

PS Thanks so much PHP, for having `htmlentities` instead of something logical like `html_entity_encode`. O-o