### PR TITLE
ImageProxy: return extension type to user

### DIFF
--- a/xExtension-ImageProxy/metadata.json
+++ b/xExtension-ImageProxy/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Image Proxy",
 	"author": "Frans de Jonge",
 	"description": "No insecure content warnings or disappearing images.",
-	"version": 0.2,
+	"version": 0.3,
 	"entrypoint": "ImageProxy",
-	"type": "system"
+	"type": "user"
 }


### PR DESCRIPTION
Fixes #16. Reverses a change that was made in relation to https://github.com/FreshRSS/FreshRSS/issues/1257

The underlying cause is something slightly different, see https://github.com/FreshRSS/FreshRSS/issues/1548#issuecomment-304434061