### PR TITLE
Suppression de l'extension Hooktube

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@aledeg](https://github.com/aledeg)
 
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
+
+### By [@Korbak](https://github.com/Korbak)
+
+* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline (fork of "YouTube" Extension) but replaces every source by Hooktube

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ There are some FreshRSS extensions out there, developed by community members:
 
 ### By [@Korbak](https://github.com/Korbak)
 
-* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline (fork of "YouTube" Extension) but replaces every source by Hooktube
+* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline and replaces every source, included the displayed video by Hooktube, a YouTube mirror that allows you to watch YouTube content without being tracked, limited or using an account.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,3 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@aledeg](https://github.com/aledeg)
 
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
-
-### By [@Korbak](https://github.com/Korbak)
-
-* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline and replaces every source by Hooktube for an enhanced privacy (no tracking or limitation) 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ There are some FreshRSS extensions out there, developed by community members:
 
 ### By [@Korbak](https://github.com/Korbak)
 
-* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline and replaces every source, included the displayed video by Hooktube, a YouTube mirror that allows you to watch YouTube content without being tracked, limited or using an account.
+* [Hooktube](https://github.com/Korbak/freshrss-Hooktube): Displays videos from YouTube feeds inline and replaces every source by Hooktube for an enhanced privacy (no tracking or limitation) 

--- a/extensions.json
+++ b/extensions.json
@@ -112,14 +112,6 @@
       "author": "Alexis Degrugillier",
       "url": "https://github.com/aledeg/FreshRSS-extensions",
       "type": "gh-subdirectory"
-    },
-    {
-      "name": "Hooktube",
-      "description": "Displays videos from YouTube feeds inline and replaces every source by Hooktube for an enhanced privacy (no tracking or limitation)",
-      "version": 0.2,
-      "author": "Korbak",
-      "url": "https://github.com/Korbak/freshrss-Hooktube",
-      "type": "gh-subdirectory"
     }
   ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "Hooktube",
-      "description": "Displays videos from YouTube feeds inline and replaces every source, included the displaye    d video by Hooktube, a YouTube mirror that allows you to watch YouTube content without being tracked, limited or using an account.",
+      "description": "Displays videos from YouTube feeds inline and replaces every source by Hooktube for an enhanced privacy (no tracking or limitation)",
       "version": 0.2,
       "author": "Korbak",
       "url": "https://github.com/Korbak/freshrss-Hooktube",

--- a/extensions.json
+++ b/extensions.json
@@ -115,7 +115,7 @@
     },
     {
       "name": "Hooktube",
-      "description": "Displays videos from YouTube feeds inline (fork of 'YouTube' Extension) but replaces every source by Hooktube",
+      "description": "Displays videos from YouTube feeds inline and replaces every source, included the displaye    d video by Hooktube, a YouTube mirror that allows you to watch YouTube content without being tracked, limited or using an account.",
       "version": 0.2,
       "author": "Korbak",
       "url": "https://github.com/Korbak/freshrss-Hooktube",

--- a/extensions.json
+++ b/extensions.json
@@ -112,6 +112,14 @@
       "author": "Alexis Degrugillier",
       "url": "https://github.com/aledeg/FreshRSS-extensions",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "Hooktube",
+      "description": "Displays videos from YouTube feeds inline (fork of 'YouTube' Extension) but replaces every source by Hooktube",
+      "version": 0.2,
+      "author": "Korbak",
+      "url": "https://github.com/Korbak/freshrss-Hooktube",
+      "type": "gh-subdirectory"
     }
   ]
 }


### PR DESCRIPTION
Hooktube étant un site tenu par un néo-nazi, l'extension Hooktube le soutenait, ce que je refuse. De ce fait, j'ai supprimé mon extension, et la supprime donc de la liste.