### PR TITLE
fixed youtube not shown as updateable

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -34,8 +34,8 @@
       "type": "gh-subdirectory"
     },
     {
-      "name": "YouTube/PeerTube",
-      "description": "Display videos from YouTube/PeerTube feeds inline",
+      "name": "YouTube",
+      "description": "Display videos from YouTube and PeerTube feeds inline",
       "version": 0.7,
       "author": "Kevin Papst",
       "url": "https://github.com/kevinpapst/freshrss-youtube",


### PR DESCRIPTION
Follow up of #31.

The extension screen compares the "entry point" of each extension with the name in extensions.json to find out if an extension is installed and if there is a new version available.

So changing its name in there is not possible/allowed.

@Frenzie ping