### PR TITLE
Add "Invidious" extension to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@aledeg](https://github.com/aledeg)
 
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
+
+### By [@Korbak](https://github.com/Korbak)
+
+* [Invidious](https://github.com/Korbak/freshrss-invidious): Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ There are some FreshRSS extensions out there, developed by community members:
 
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
 
+
+### By [@Lapineige](https://github.com/lapineige)
+
+* [Reading Time](https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime): Add a reading time estimation next to each article.
+
+
 ### By [@Korbak](https://github.com/Korbak)
 
 * [Invidious](https://github.com/Korbak/freshrss-invidious): Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)

--- a/extensions.json
+++ b/extensions.json
@@ -112,6 +112,14 @@
       "author": "Alexis Degrugillier",
       "url": "https://github.com/aledeg/FreshRSS-extensions",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "Invidious",
+      "description": "Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)",
+      "version": 1.0,
+      "author": "Korbak",
+      "url": "https://github.com/Korbak/freshrss-invidious",
+      "type": "gh-subdirectory"
     }
   ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -114,6 +114,22 @@
       "type": "gh-subdirectory"
     },
     {
+      "name": "ReadingTime",
+      "description": "Add a reading time estimation for each article",
+      "version": 1.0,
+      "author": "Lapineige",
+      "url": "https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/",
+      "type": "gh-subdirectory"
+    },
+    {
+      "name": "ThreePanesView",
+      "version": 1.3,
+      "description": "Adds a third vertical pane along the article list, to display the article's content.",
+      "author": "Nicolas <nicofrand> Frandeboeuf",
+      "url": "https://framagit.org/nicofrand/xextension-threepanesview",
+      "type": "gh-subdirectory"
+    },
+    {
       "name": "Invidious",
       "description": "Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)",
       "version": 1.0,


### PR DESCRIPTION
Hi,

I adapted the YouTube extension to allow the youtube.com URLs and display to be replaced by any Invidious extension.

It lets people use this decentralized YouTube front-end easily while not encouraging YouTube's business model, tracking, ads, etc.