### PR TITLE
Add "Invidious" extension to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,8 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@Lapineige](https://github.com/lapineige)
 
 * [Reading Time](https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime): Add a reading time estimation next to each article.
+
+
+### By [@Korbak](https://github.com/Korbak)
+
+* [Invidious](https://github.com/Korbak/freshrss-invidious): Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)

--- a/extensions.json
+++ b/extensions.json
@@ -128,6 +128,14 @@
       "author": "Nicolas <nicofrand> Frandeboeuf",
       "url": "https://framagit.org/nicofrand/xextension-threepanesview",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "Invidious",
+      "description": "Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)",
+      "version": 1.0,
+      "author": "Korbak",
+      "url": "https://github.com/Korbak/freshrss-invidious",
+      "type": "gh-subdirectory"
     }
   ]
 }


### PR DESCRIPTION
Hi,

I adapted the YouTube extension to allow the youtube.com URLs and display to be replaced by any Invidious extension.

It lets people use this decentralized YouTube front-end easily while not encouraging YouTube's business model, tracking, ads, etc.