### PR TITLE
Update CustomCSS metadata.json to version 0.2

### DIFF
--- a/xExtension-CustomCSS/metadata.json
+++ b/xExtension-CustomCSS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom CSS",
 	"author": "Marien Fressinaud",
 	"description": "Give possibility to overwrite the CSS with a user-specific rules.",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "CustomCSS",
 	"type": "user"
 }


### PR DESCRIPTION
When installed the extension will show there is an update available because this file says version `0.1` where the main [`extensions.json`](https://github.com/FreshRSS/Extensions/blob/master/extensions.json) shows version `0.2` is the latest which is inline with the extension README