### PR TITLE
Bump freshrss-youtube extension version.

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -36,7 +36,7 @@
     {
       "name": "YouTube",
       "description": "Display videos from YouTube and PeerTube feeds inline",
-      "version": 0.9,
+      "version": 0.10,
       "author": "Kevin Papst",
       "url": "https://github.com/kevinpapst/freshrss-youtube",
       "type": "gh-subdirectory"


### PR DESCRIPTION
The FreshRSS YouTube extension from Kevin Papst was updated to version 0.10

https://github.com/kevinpapst/freshrss-youtube/commit/06f346789893adbfed10fa00ecf01f6ae14b6282