### PR TITLE
Allow Apache-friendly fine-tuning

### DIFF
--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -59,7 +59,11 @@ RewriteRule ^ http://%1 [QSA,P,L]
   Satisfy any
 </Location>
 # CRITICAL: Do NOT allow access to local resources!!!
-<LocationMatch "^/proxy/.*(localhost|127\.0\.0\.1|::1|local\.domain)">
+#  - (any) IPv4
+#  - (any) IPv6
+#  - localhost
+#  - local.domain (e.g. example.org)
+<LocationMatch "^/proxy/https?:/+([0-9]{1,3}(\.[0-9]{1,3}){3}|([0-9a-zA-Z]{0,4}:?)?(:[0-9a-zA-Z]{1,4}:){0,6}([.:][0-9a-zA-Z]{1,4}){1,7}|[^/]*(localhost|local\.domain|example\.org))(/|$)">
   Require all denied
 </LocationMatch>
 ```

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -12,7 +12,8 @@ To use it, upload this entire directory to the FreshRSS `./extensions` directory
 
 * `scheme_https` (default: `0`): whether to proxy HTTPS resources
 
-* `scheme_default` (default: `http`): which scheme to use for resources that do not include one (if set to `-`, those will not be proxied)
+* `scheme_default` (default: `auto`): which scheme to use for resources that do not include one; if set to `-`, those will not be proxied;
+  if set along `scheme_include`, the scheme included in the URL will either be `auto`-matically derived from your current connection or the one explicitly specified
 
 * `scheme_include` (default: `0`): whether to include the scheme - `http*://` - in the proxied URL
 

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -39,7 +39,7 @@ In order to use Apache `mod_rewrite`, you will need to set the following setting
 Along the following Apache configuration for the `www.example.org` virtual host:
 
 ```
-  # WARNING: Multiple '/' are trimmed to a single one!
+  # WARNING: Multiple '/' in %{REQUEST_URI} are internally trimmed to a single one!
   RewriteCond %{REQUEST_URI} ^/proxy/https:/+(.*)$
   RewriteRule ^ https://%1 [QSA,P,L]
   RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -28,7 +28,7 @@ The source code for the images.weserv.nl proxy can be found at [github.com/andri
 
 ### Apache configuration
 
-In order to use Apache `mod_rewrite`, you will need to set the following settings:
+In order to use Apache [mod_rewrite](https://httpd.apache.org/docs/current/mod/mod_rewrite.html), you will need to set the following settings:
 
 * `proxy_url` = **https://www.example.org/proxy/**
 

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -40,26 +40,26 @@ In order to use Apache [mod_rewrite](https://httpd.apache.org/docs/current/mod/m
 Along the following Apache configuration for the `www.example.org` virtual host:
 
 ```
-  # WARNING: Multiple '/' in %{REQUEST_URI} are internally trimmed to a single one!
-  RewriteCond %{REQUEST_URI} ^/proxy/https:/+(.*)$
-  RewriteRule ^ https://%1 [QSA,P,L]
-  RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$
-  RewriteRule ^ http://%1 [QSA,P,L]
-  # CRITICAL: Do NOT leave your proxy open to everyone!!!
-  <Location "/proxy/">
-    # Local network
-    Require ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8
-    # Users
-    AuthType Basic
-    AuthName "Proxy - Authorized Users ONLY"
-    AuthBasicProvider file
-    AuthUserFile /etc/apache2/htpasswd/users
-    Require valid-user
-    # Local network OR authenticated users
-    Satisfy any
-  </Location>
-  # CRITICAL: Do NOT allow access to local resources!!!
-  <LocationMatch "^/proxy/.*(localhost|127\.0\.0\.1|::1|local\.domain)">
-    Require all denied
-  </LocationMatch>
+# WARNING: Multiple '/' in %{REQUEST_URI} are internally trimmed to a single one!
+RewriteCond %{REQUEST_URI} ^/proxy/https:/+(.*)$
+RewriteRule ^ https://%1 [QSA,P,L]
+RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$
+RewriteRule ^ http://%1 [QSA,P,L]
+# CRITICAL: Do NOT leave your proxy open to everyone!!!
+<Location "/proxy/">
+  # Local network
+  Require ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8
+  # Users
+  AuthType Basic
+  AuthName "Proxy - Authorized Users ONLY"
+  AuthBasicProvider file
+  AuthUserFile /etc/apache2/htpasswd/users
+  Require valid-user
+  # Local network OR authenticated users
+  Satisfy any
+</Location>
+# CRITICAL: Do NOT allow access to local resources!!!
+<LocationMatch "^/proxy/.*(localhost|127\.0\.0\.1|::1|local\.domain)">
+  Require all denied
+</LocationMatch>
 ```

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -30,7 +30,7 @@ The source code for the images.weserv.nl proxy can be found at [github.com/andri
 
 In order to use Apache `mod_rewrite`, you will need to set the following settings:
 
-* `proxy_url` = ``https://www.example.org/proxy/``
+* `proxy_url` = **https://www.example.org/proxy/**
 
 * `scheme_include` = **1**
 

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -45,7 +45,7 @@ Along the following Apache configuration for the `www.example.org` virtual host:
   RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$
   RewriteRule ^ http://%1 [QSA,P,L]
   <Location "/proxy/">
-    # CRITICAL: Do NOT leave your proxy opened to everyone!!!
+    # CRITICAL: Do NOT leave your proxy open to everyone!!!
     # Local network
     Require ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8
     # Users

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -63,7 +63,7 @@ RewriteRule ^ http://%1 [QSA,P,L]
 #  - (any) IPv6
 #  - localhost
 #  - local.domain (e.g. example.org)
-<LocationMatch "^/proxy/https?:/+([0-9]{1,3}(\.[0-9]{1,3}){3}|([0-9a-zA-Z]{0,4}:?)?(:[0-9a-zA-Z]{1,4}:){0,6}([.:][0-9a-zA-Z]{1,4}){1,7}|[^/]*(localhost|local\.domain|example\.org))(/|$)">
+<LocationMatch "^/proxy/https?:/+([0-9]{1,3}(\.[0-9]{1,3}){3}|([0-9a-fA-F]{0,4}:?)?(:[0-9a-fA-F]{1,4}:){0,6}([.:][0-9a-fA-F]{1,4}){1,7}|[^/]*(localhost|local\.domain|example\.org))(/|$)">
   Require all denied
 </LocationMatch>
 ```

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -45,8 +45,8 @@ Along the following Apache configuration for the `www.example.org` virtual host:
   RewriteRule ^ https://%1 [QSA,P,L]
   RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$
   RewriteRule ^ http://%1 [QSA,P,L]
+  # CRITICAL: Do NOT leave your proxy open to everyone!!!
   <Location "/proxy/">
-    # CRITICAL: Do NOT leave your proxy open to everyone!!!
     # Local network
     Require ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8
     # Users
@@ -58,4 +58,8 @@ Along the following Apache configuration for the `www.example.org` virtual host:
     # Local network OR authenticated users
     Satisfy any
   </Location>
+  # CRITICAL: Do NOT allow access to local resources!!!
+  <LocationMatch "^/proxy/.*(localhost|127\.0\.0\.1|::1|local\.domain)">
+    Require all denied
+  </LocationMatch>
 ```

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -24,7 +24,7 @@ By default this extension will use the [images.weserv.nl](https://images.weserv.
 
 By ticking the `scheme_https` checkbox, you can also force the use of the proxy, even for images coming through an encrypted channel. This makes the server that hosts your FreshRSS instance the only point of entry for images, preventing your client from connecting directly to the RSS sources to recover them (which could be a privacy concern in extreme cases).
 
-The source code for the images.weserv.nl proxy can be found at [github.com/andrieslouw/imagesweserv](https://github.com/andrieslouw/imagesweserv), but of course other methods are available. For example, in Apache you could [use `mod_rewrite` to set up a simple proxy](https://httpd.apache.org/docs/2.2/rewrite/proxy.html) and similar methods are available in nginx and lighttpd. Alternatively you could use a simple PHP script, [along these lines](https://github.com/Alexxz/Simple-php-proxy-script). Keep in mind that too simple a proxy could introduce security risks, which is why the default proxy processes the images.
+The source code for the images.weserv.nl proxy can be found at [github.com/andrieslouw/imagesweserv](https://github.com/andrieslouw/imagesweserv), but of course other methods are available. For example, in Apache you could [use `mod_rewrite` to set up a simple proxy](#apache-configuration) and similar methods are available in nginx and lighttpd. Alternatively you could use a simple PHP script, [along these lines](https://github.com/Alexxz/Simple-php-proxy-script). Keep in mind that too simple a proxy could introduce security risks, which is why the default proxy processes the images.
 
 ### Apache configuration
 

--- a/xExtension-ImageProxy/README.md
+++ b/xExtension-ImageProxy/README.md
@@ -4,10 +4,57 @@ This FreshRSS extension allows you to get rid of insecure content warnings or di
 
 To use it, upload this entire directory to the FreshRSS `./extensions` directory on your server and enable it on the extension panel in FreshRSS.
 
+## Configuration settings
+
+* `proxy_url` (default: `https://images.example.com/?url=`): the URL that is prependended to the original image URL
+
+* `scheme_http` (default: `1`): whether to proxy HTTP resources
+
+* `scheme_https` (default: `0`): whether to proxy HTTPS resources
+
+* `scheme_default` (default: `http`): which scheme to use for resources that do not include one (if set to `-`, those will not be proxied)
+
+* `scheme_include` (default: `0`): whether to include the scheme - `http*://` - in the proxied URL
+
+* `url_encode` (default: `1`): whether to URL-encode (RFC 3986) the proxied URL
+
 ## Proxy Settings
 
 By default this extension will use the [images.weserv.nl](https://images.weserv.nl) image caching and resizing proxy, but instead you can supply your own proxy URL in the settings. An example URL would look like ``https://images.example.com/?url=``.
 
+By ticking the `scheme_https` checkbox, you can also force the use of the proxy, even for images coming through an encrypted channel. This makes the server that hosts your FreshRSS instance the only point of entry for images, preventing your client from connecting directly to the RSS sources to recover them (which could be a privacy concern in extreme cases).
+
 The source code for the images.weserv.nl proxy can be found at [github.com/andrieslouw/imagesweserv](https://github.com/andrieslouw/imagesweserv), but of course other methods are available. For example, in Apache you could [use `mod_rewrite` to set up a simple proxy](https://httpd.apache.org/docs/2.2/rewrite/proxy.html) and similar methods are available in nginx and lighttpd. Alternatively you could use a simple PHP script, [along these lines](https://github.com/Alexxz/Simple-php-proxy-script). Keep in mind that too simple a proxy could introduce security risks, which is why the default proxy processes the images.
 
-By ticking the dedicated checkbox, you can also force the use of the proxy, even for images coming through an encrypted channel. This makes the server that hosts your FreshRSS instance the only point of entry for images, preventing your client from connecting directly to the RSS sources to recover them (which could be a privacy concern in extreme cases).
+### Apache configuration
+
+In order to use Apache `mod_rewrite`, you will need to set the following settings:
+
+* `proxy_url` = ``https://www.example.org/proxy/``
+
+* `scheme_include` = **1**
+
+* `url_encode` = **0**
+
+Along the following Apache configuration for the `www.example.org` virtual host:
+
+```
+  # WARNING: Multiple '/' are trimmed to a single one!
+  RewriteCond %{REQUEST_URI} ^/proxy/https:/+(.*)$
+  RewriteRule ^ https://%1 [QSA,P,L]
+  RewriteCond %{REQUEST_URI} ^/proxy/http:/+(.*)$
+  RewriteRule ^ http://%1 [QSA,P,L]
+  <Location "/proxy/">
+    # CRITICAL: Do NOT leave your proxy opened to everyone!!!
+    # Local network
+    Require ip 192.168.0.0/16 172.16.0.0/12 10.0.0.0/8
+    # Users
+    AuthType Basic
+    AuthName "Proxy - Authorized Users ONLY"
+    AuthBasicProvider file
+    AuthUserFile /etc/apache2/htpasswd/users
+    Require valid-user
+    # Local network OR authenticated users
+    Satisfy any
+  </Location>
+```

--- a/xExtension-ImageProxy/configure.phtml
+++ b/xExtension-ImageProxy/configure.phtml
@@ -5,9 +5,40 @@
 		<div class="group-controls">
 			<input type="url" name="image_proxy_url" id="image_proxy_url" value="<?php echo FreshRSS_Context::$user_conf->image_proxy_url; ?>">
 		</div>
-		<label class="group-name" for="image_proxy_force"><?php echo _t('ext.imageproxy.force'); ?></label>
+	</div>
+	<div class="form-group">
+		<label class="group-name" for="image_proxy_scheme_http"><?php echo _t('ext.imageproxy.scheme_http'); ?></label>
 		<div class="group-controls">
-			<input type="checkbox" name="image_proxy_force" id="image_proxy_force" value="1" <?php echo (FreshRSS_Context::$user_conf->image_proxy_force ? 'checked' : ''); ?>>
+			<input type="checkbox" name="image_proxy_scheme_http" id="image_proxy_scheme_http" value="1" <?php echo (FreshRSS_Context::$user_conf->image_proxy_scheme_http ? 'checked' : ''); ?>>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="group-name" for="image_proxy_scheme_https"><?php echo _t('ext.imageproxy.scheme_https'); ?></label>
+		<div class="group-controls">
+			<input type="checkbox" name="image_proxy_scheme_https" id="image_proxy_scheme_https" value="1" <?php echo (FreshRSS_Context::$user_conf->image_proxy_scheme_https ? 'checked' : ''); ?>>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="group-name" for="image_proxy_scheme_default"><?php echo _t('ext.imageproxy.scheme_default'); ?></label>
+		<div class="group-controls">
+			<select name="image_proxy_scheme_default" id="image_proxy_scheme_default">
+				<option value="<?php echo htmlentities(FreshRSS_Context::$user_conf->image_proxy_scheme_default); ?>" selected="selected"><?php echo htmlentities(FreshRSS_Context::$user_conf->image_proxy_scheme_default); ?></option>
+				<option value="-">-</option>
+				<option value="http">http</option>
+				<option value="https">https</option>
+			</select>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="group-name" for="image_proxy_scheme_include"><?php echo _t('ext.imageproxy.scheme_include'); ?></label>
+		<div class="group-controls">
+			<input type="checkbox" name="image_proxy_scheme_include" id="image_proxy_scheme_include" value="1" <?php echo (FreshRSS_Context::$user_conf->image_proxy_scheme_include ? 'checked' : ''); ?>>
+		</div>
+	</div>
+	<div class="form-group">
+		<label class="group-name" for="image_proxy_url_encode"><?php echo _t('ext.imageproxy.url_encode'); ?></label>
+		<div class="group-controls">
+			<input type="checkbox" name="image_proxy_url_encode" id="image_proxy_url_encode" value="1" <?php echo (FreshRSS_Context::$user_conf->image_proxy_url_encode ? 'checked' : ''); ?>>
 		</div>
 	</div>
 

--- a/xExtension-ImageProxy/configure.phtml
+++ b/xExtension-ImageProxy/configure.phtml
@@ -24,6 +24,7 @@
 			<select name="image_proxy_scheme_default" id="image_proxy_scheme_default">
 				<option value="<?php echo htmlentities(FreshRSS_Context::$user_conf->image_proxy_scheme_default); ?>" selected="selected"><?php echo htmlentities(FreshRSS_Context::$user_conf->image_proxy_scheme_default); ?></option>
 				<option value="-">-</option>
+				<option value="auto">auto</option>
 				<option value="http">http</option>
 				<option value="https">https</option>
 			</select>

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -5,7 +5,7 @@ class ImageProxyExtension extends Minz_Extension {
 	private const PROXY_URL = 'https://images.weserv.nl/?url=';
 	private const SCHEME_HTTP = '1';
 	private const SCHEME_HTTPS = '';
-	private const SCHEME_DEFAULT = 'http';
+	private const SCHEME_DEFAULT = 'auto';
 	private const SCHEME_INCLUDE = '';
 	private const URL_ENCODE = '1';
 
@@ -78,9 +78,18 @@ class ImageProxyExtension extends Minz_Extension {
 			}
 		}
 		else if (empty($scheme)) {
-			if (substr(FreshRSS_Context::$user_conf->image_proxy_scheme_default,0, 4) !== 'http') return $url;
-			if (FreshRSS_Context::$user_conf->image_proxy_scheme_include) {
-				$url = FreshRSS_Context::$user_conf->image_proxy_scheme_default . '://' . $url;
+			if (FreshRSS_Context::$user_conf->image_proxy_scheme_default === 'auto') {
+				if (FreshRSS_Context::$user_conf->image_proxy_scheme_include) {
+					$url = ((!empty($_SERVER['HTTPS']) && strtolower($_SERVER['HTTPS'])!== 'off') ? 'https:' : 'http:') . $url;
+				}
+			}
+			else if (substr(FreshRSS_Context::$user_conf->image_proxy_scheme_default, 0, 4) === 'http') {
+				if (FreshRSS_Context::$user_conf->image_proxy_scheme_include) {
+					$url = FreshRSS_Context::$user_conf->image_proxy_scheme_default . ':' . $url;
+				}
+			}
+			else {  // do not proxy unschemed ("//path/...") URLs
+				return $url;
 			}
 		}
 		else {  // unknown/unsupported (non-http) scheme

--- a/xExtension-ImageProxy/i18n/en/ext.php
+++ b/xExtension-ImageProxy/i18n/en/ext.php
@@ -3,7 +3,11 @@
 return array(
 	'imageproxy' => array(
 		'proxy_url' => 'Proxy URL',
-		'force' => 'Force proxying, even for https',
+		'scheme_http' => 'Proxy HTTP',
+		'scheme_https' => 'Proxy HTTPS',
+		'scheme_default' => 'Proxy unspecified',
+		'scheme_include' => 'Include http*:// in URL',
+		'url_encode' => 'Encode the URL',
 		'true' => 'On',
 		'false' => 'Off',
 	),

--- a/xExtension-ImageProxy/i18n/fr/ext.php
+++ b/xExtension-ImageProxy/i18n/fr/ext.php
@@ -3,7 +3,11 @@
 return array(
 	'imageproxy' => array(
 		'proxy_url' => 'URL du proxy',
-		'force' => 'Toujours utiliser le proxy, même en https',
+		'scheme_http' => 'Proxy HTTP',
+		'scheme_https' => 'Proxy HTTPS',
+		'scheme_default' => 'Proxy indéterminées',
+		'scheme_include' => 'Inclure http*:// dans l\'URL',
+		'url_encode' => 'Encoder l\'URL',
 		'true' => 'Oui',
 		'false' => 'Non',
 	),

--- a/xExtension-ImageProxy/i18n/fr/ext.php
+++ b/xExtension-ImageProxy/i18n/fr/ext.php
@@ -5,7 +5,7 @@ return array(
 		'proxy_url' => 'URL du proxy',
 		'scheme_http' => 'Proxy HTTP',
 		'scheme_https' => 'Proxy HTTPS',
-		'scheme_default' => 'Proxy indéterminées',
+		'scheme_default' => 'Proxy indéterminé',
 		'scheme_include' => 'Inclure http*:// dans l\'URL',
 		'url_encode' => 'Encoder l\'URL',
 		'true' => 'Oui',

--- a/xExtension-ImageProxy/metadata.json
+++ b/xExtension-ImageProxy/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Image Proxy",
 	"author": "Frans de Jonge",
 	"description": "No insecure content warnings or disappearing images.",
-	"version": 0.4,
+	"version": 0.5,
 	"entrypoint": "ImageProxy",
 	"type": "user"
 }


### PR DESCRIPTION
Hello,

This PR adds additional parameters to the `ImageProxy` extension such as to allow easy proxying via Apache `mod_rewrite` (which: 1. needs a hard-coded _absolute path_ ; 2. can not URL-decode passed URL)

See the updated `README.md` for further information (and corresponding Apache configuration example).

I've taken care to remain backward-compatible with existing setups; in particular, the (former) `force` parameter will automatically be migrated to the (new) `scheme_https` counterpart.

Best,

Cédric