### PR TITLE
restore php5.6 compatibility

### DIFF
--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -2,12 +2,12 @@
 
 class ImageProxyExtension extends Minz_Extension {
 	// Defaults
-	private const PROXY_URL = 'https://images.weserv.nl/?url=';
-	private const SCHEME_HTTP = '1';
-	private const SCHEME_HTTPS = '';
-	private const SCHEME_DEFAULT = 'auto';
-	private const SCHEME_INCLUDE = '';
-	private const URL_ENCODE = '1';
+	const PROXY_URL = 'https://images.weserv.nl/?url=';
+	const SCHEME_HTTP = '1';
+	const SCHEME_HTTPS = '';
+	const SCHEME_DEFAULT = 'auto';
+	const SCHEME_INCLUDE = '';
+	const URL_ENCODE = '1';
 
 	public function init() {
 		$this->registerHook('entry_before_display',


### PR DESCRIPTION
old version of php doesn't support visibility on class const

Sorry, my server have an old version of debian and php (debian 8 - php5.6). I think i'm not alone so I purpose this small change (Tested live on my production server as very a professional developer^^).

Do whatever you want with this proposal.

Best regards