### PR TITLE
Add "GReader Redate" extension.

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -163,9 +163,9 @@
     },
     {
       "name": "GReader Redate",
-      "description": "Workaround a dating problem on GReader API with Reeder and EasyRSS.",
+      "description": "Works around a dating problem on GReader API with Reeder.",
       "version": 1.0,
-      "author": "Julien Avérous",
+      "author": "Julien AvÃ©rous",
       "url": "https://github.com/javerous/freshrss-greader-redate",
       "type": "gh-subdirectory"
     }

--- a/extensions.json
+++ b/extensions.json
@@ -160,6 +160,14 @@
       "author": "Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "GReader Redate",
+      "description": "Workaround a dating problem on GReader API with Reeder and EasyRSS.",
+      "version": 1.0,
+      "author": "Julien Avérous",
+      "url": "https://github.com/javerous/freshrss-greader-redate",
+      "type": "gh-subdirectory"
     }
   ]
 }

--- a/extensions.json
+++ b/extensions.json
@@ -163,7 +163,7 @@
     },
     {
       "name": "GReader Redate",
-      "description": "Works around a dating problem on GReader API with Reeder.",
+      "description": "Works around a dating problem on GReader API with Reeder and EasyRSS (prior to 0.7.5).",
       "version": 1.0,
       "author": "Julien Avérous",
       "url": "https://github.com/javerous/freshrss-greader-redate",


### PR DESCRIPTION
Add the Greader Redate extension as suggested there https://github.com/FreshRSS/Extensions/issues/72

It's related to the (long) discussion there https://github.com/FreshRSS/FreshRSS/issues/2759

I know that @Alkarex fixed the problem in EasyRSS, but for now I would prefer to keep it in my extension, so the workaround is still possible for those who still use the old version. Perhaps the description can specify a version for EasyRSS ? But there are different forks, if I understand well, so… :s