### PR TITLE
fix: Replace _url() call by Minz_Url::display (ShareByEmail)

### DIFF
--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -9,7 +9,7 @@ class ShareByEmailExtension extends Minz_Extension {
 
 		FreshRSS_Share::register([
 			'type' => 'email',
-			'url' => _url('shareByEmail', 'share') . '&amp;id=~ID~',
+			'url' => Minz_Url::display(['c' => 'shareByEmail', 'a' => 'share']) . '&amp;id=~ID~',
 			'transform' => [],
 			'form' => 'simple',
 			'method' => 'GET',


### PR DESCRIPTION
The `_url()` helper method wasn't loaded when the extension was
initialized via the API.