### PR TITLE
Add RSS-Bridge extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,7 @@ There are some FreshRSS extensions out there, developed by community members:
 
 * [YouTube Channel 2 RSSFeed](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-YouTubeChannel2RssFeed): You can add a YouTube Channel URL and will get it as RSSFeed
 * [Feed Title Builder](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-FeedTitleBuilder): Build your own feed title based on url, the original feed title and the date the feed was added
+
+### By [@DevonHess](https://github.com/DevonHess)
+
+* [RSS-Bridge](https://github.com/DevonHess/FreshRSS-Extensions/tree/main/xExtension-RssBridge): Run URLs through [RSS-Bridge](https://github.com/rss-bridge/rss-bridge) detection

--- a/extensions.json
+++ b/extensions.json
@@ -187,7 +187,6 @@
     },
     {
       "name": "Quick Collapse",
-      "description": "Improve the sharing by email system.",
       "description": "Quickly change from folded to unfolded articles",
       "version": 0.1,
       "author": "romibi and Marien Fressinaud",

--- a/extensions.json
+++ b/extensions.json
@@ -193,6 +193,14 @@
       "author": "romibi and Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "RSS-Bridge",
+      "description": "Run URLs through <a href=\"https://github.com/rss-bridge/rss-bridge\">RSS-Bridge</a> detection",
+      "version": 1,
+      "author": "Devon Hess",
+      "url": "https://github.com/DevonHess/FreshRSS-Extensions",
+      "type": "gh-subdirectory"
     }
   ]
 }


### PR DESCRIPTION
Added an extension to run any URL you add through [RSS-Bridge](https://github.com/rss-bridge/rss-bridge).

RSS-Bridge is a project that creates RSS feeds for websites that don't have one. This plugin basically allows FreshRSS to support feeds from hundreds of new websites.

It's a very simple extension. If RSS-Bridge doesn't support the feed, FreshRSS will try to add your URL normally, but if it does support the feed, it'll add an RSS-Bridge feed instead.

This is my first ever pull request. Let me know if I did anything wrong/stupid. Thanks.