### PR TITLE
Fix extension definitions

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -4,7 +4,7 @@
     {
       "name": "Custom CSS",
       "description": "A FreshRSS extension which give ability to create user-specific CSS rules to apply in addition of the actual theme",
-      "version": 0.2,
+      "version": 0.3,
       "author": "Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -12,7 +12,7 @@
     {
       "name": "Custom JS",
       "description": "A FreshRSS extension which give ability to create user-specific Javascript rules to apply in addition of the actual theme",
-      "version": 0.2,
+      "version": 0.3,
       "author": "Frans de Jonge",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -20,7 +20,7 @@
     {
       "name": "Image Proxy",
       "description": "No insecure content warnings or disappearing images on https sites",
-      "version": 0.4,
+      "version": 0.6,
       "author": "Frans de Jonge",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -28,7 +28,7 @@
     {
       "name": "Sticky Feeds",
       "description": "Set the feed aside in the main stream following the window scroll",
-      "version": 0.1,
+      "version": 0.2,
       "author": "Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -68,9 +68,9 @@
     {
       "name": "Keep Folder State",
       "description": "Stores the state of the folders locally and expand them automatically if necessary",
-      "version": 0.1,
+      "version": 0.2,
       "author": "Marco Heizmann",
-      "url": "https://github.com/oyox/FreshRSS-extensions",
+      "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
     },
     {
@@ -116,9 +116,9 @@
     {
       "name": "Reading Time",
       "description": "Add a reading time estimation for each article",
-      "version": 1.0,
+      "version": 1.3,
       "author": "Lapineige",
-      "url": "https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/",
+      "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
     },
     {
@@ -156,7 +156,7 @@
     {
       "name": "Share By Email",
       "description": "Improve the sharing by email system.",
-      "version": 0.1,
+      "version": 0.2,
       "author": "Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -188,7 +188,7 @@
     {
       "name": "Quick Collapse",
       "description": "Quickly change from folded to unfolded articles",
-      "version": 0.1,
+      "version": 0.2,
       "author": "romibi and Marien Fressinaud",
       "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
@@ -207,6 +207,22 @@
       "version": 1,
       "author": "Kapdap",
       "url": "https://github.com/Kapdap/freshrss-extensions",
+      "type": "gh-subdirectory"
+    },
+    {
+      "name": "TinyTinyRSS API",
+      "description": "Provides an API compliant with TinyTinyRSS applications.",
+      "version": 0.2,
+      "author": "Marien Fressinaud",
+      "url": "https://github.com/FreshRSS/Extensions",
+      "type": "gh-subdirectory"
+    },
+    {
+      "name": "Title-Wrap",
+      "description": "Applies a line-wrap to long article titles, as opposed to truncating the title when it overflows its display area.",
+      "version": 0.2,
+      "author": "Frans de Jonge, Joris Kinable",
+      "url": "https://github.com/FreshRSS/Extensions",
       "type": "gh-subdirectory"
     }
   ]

--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -1,6 +1,14 @@
 <?php
 
 class CustomCSSExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
 	public function init() {
 		$this->registerTranslates();
 

--- a/xExtension-CustomCSS/metadata.json
+++ b/xExtension-CustomCSS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom CSS",
 	"author": "Marien Fressinaud",
 	"description": "Give possibility to overwrite the CSS with a user-specific rules.",
-	"version": 0.2,
+	"version": 0.3,
 	"entrypoint": "CustomCSS",
 	"type": "user"
 }

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -1,6 +1,14 @@
 <?php
 
 class CustomJSExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
 	public function init() {
 		$this->registerTranslates();
 

--- a/xExtension-CustomJS/metadata.json
+++ b/xExtension-CustomJS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom JS",
 	"author": "₣rans de Jonge",
 	"description": "Apply custom JS.",
-	"version": 0.2,
+	"version": 0.3,
 	"entrypoint": "CustomJS",
 	"type": "user"
 }

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -9,6 +9,14 @@ class ImageProxyExtension extends Minz_Extension {
 	const SCHEME_INCLUDE = '';
 	const URL_ENCODE = '1';
 
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
 	public function init() {
 		$this->registerHook('entry_before_display',
 		                    array('ImageProxyExtension', 'setImageProxyHook'));

--- a/xExtension-ImageProxy/metadata.json
+++ b/xExtension-ImageProxy/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Image Proxy",
 	"author": "Frans de Jonge",
 	"description": "No insecure content warnings or disappearing images.",
-	"version": 0.5,
+	"version": 0.6,
 	"entrypoint": "ImageProxy",
 	"type": "user"
 }

--- a/xExtension-KeepFolderState/extension.php
+++ b/xExtension-KeepFolderState/extension.php
@@ -1,6 +1,16 @@
 <?php
 
 class KeepFolderStateExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+    }
 
     public function init() {
         Minz_View::appendScript($this->getFileUrl('jquerymin.js', 'js'),'','','');

--- a/xExtension-KeepFolderState/metadata.json
+++ b/xExtension-KeepFolderState/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Keep Folder State",
 	"author": "Marco Heizmann",
 	"description": "Stores the state of the folders locally and expand them automatically if necessary.",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "KeepFolderState",
 	"type": "user"
 }

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -1,6 +1,17 @@
 <?php
 
 class QuickCollapseExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
 		$this->registerTranslates();
 		$this->registerViews();

--- a/xExtension-QuickCollapse/metadata.json
+++ b/xExtension-QuickCollapse/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Quick Collapse",
 	"author": "romibi and Marien Fressinaud",
 	"description": "Quickly change from folded to unfolded articles",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "QuickCollapse",
 	"type": "user"
 }

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -1,5 +1,16 @@
 <?php
 class ReadingTimeExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
 	}

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ReadingTime",
 	"author": "Lapineige",
 	"description": "Add a reading time estimation next to each article title",
-	"version": 1.2,
+	"version": 1.3,
 	"entrypoint": "ReadingTime",
 	"type": "user"
 }

--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -1,6 +1,17 @@
 <?php
 
 class ShareByEmailExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
 		$this->registerTranslates();
 

--- a/xExtension-ShareByEmail/metadata.json
+++ b/xExtension-ShareByEmail/metadata.json
@@ -2,7 +2,7 @@
   "name": "Share By Email",
   "author": "Marien Fressinaud",
   "description": "Improve the sharing by email system.",
-  "version": 0.1,
+  "version": 0.2,
   "entrypoint": "ShareByEmail",
   "type": "user"
 }

--- a/xExtension-StickyFeeds/extension.php
+++ b/xExtension-StickyFeeds/extension.php
@@ -1,6 +1,17 @@
 <?php
 
 class StickyFeedsExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
 		Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));
 		Minz_View::appendScript($this->getFileUrl('script.js', 'js'));

--- a/xExtension-StickyFeeds/metadata.json
+++ b/xExtension-StickyFeeds/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Sticky Feeds",
 	"author": "Marien Fressinaud",
 	"description": "Set the feed aside in the main stream following the window scroll.",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "StickyFeeds",
 	"type": "user"
 }

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -1,6 +1,9 @@
 <?php
 
 class TTRSS_APIExtension extends Minz_Extension {
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
 		$this->registerHook('post_update',
 		                    array($this, 'postUpdateHook'));

--- a/xExtension-TTRSS_API/metadata.json
+++ b/xExtension-TTRSS_API/metadata.json
@@ -2,7 +2,7 @@
 	"name": "TinyTinyRSS API",
 	"author": "Marien Fressinaud",
 	"description": "Provides an API compliant with TinyTinyRSS applications.",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "TTRSS_API",
 	"type": "system"
 }

--- a/xExtension-TitleWrap/extension.php
+++ b/xExtension-TitleWrap/extension.php
@@ -1,7 +1,18 @@
 <?php
 
 class TitleWrapExtension extends Minz_Extension {
+	public function install() {
+		return true;
+	}
+
+	public function uninstall() {
+		return true;
+	}
+
+	public function handleConfigureAction() {
+	}
+
 	public function init() {
-                Minz_View::appendStyle($this->getFileUrl('title_wrap.css', 'css'));
+		Minz_View::appendStyle($this->getFileUrl('title_wrap.css', 'css'));
 	}
 }

--- a/xExtension-TitleWrap/metadata.json
+++ b/xExtension-TitleWrap/metadata.json
@@ -1,8 +1,8 @@
 {
 	"name": "Title-Wrap",
-	"author": "₣rans de Jonge, Joris Kinable",
+	"author": "Frans de Jonge, Joris Kinable",
 	"description": "Applies a line-wrap to long article titles, as opposed to truncating the title when it overflows its display area.",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "TitleWrap",
 	"type": "user"
 }


### PR DESCRIPTION
Before, extensions were missing the definition of mandatory methods.
At the moment, it's not a problem because the coding guidelines are not
enforced by the code. But in the future, it will break.
Now, extensions have all mandatory method definitions.