### PR TITLE
add new extension "Copy2Clipboard" and bump version of extension "YouTubeChannel2RSSFeed"

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ There are some FreshRSS extensions out there, developed by community members:
 
 * [YouTube Channel 2 RSSFeed](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-YouTubeChannel2RssFeed): You can add a YouTube Channel URL and will get it as RSSFeed
 * [Feed Title Builder](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-FeedTitleBuilder): Build your own feed title based on url, the original feed title and the date the feed was added
+* [Copy 2 Clipboard](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-Copy2Clipboard): Add a button in the navigation bar to copy the destination links of all visible entries into clipboard
 
 ### By [@DevonHess](https://github.com/DevonHess)
 

--- a/extensions.json
+++ b/extensions.json
@@ -140,7 +140,7 @@
     {
       "name": "YouTubeChannel2RssFeed",
       "description": "Transfer YouTube Channel URL into RSS Feed URL",
-      "version": 0.1,
+      "version": 0.2,
       "author": "CNTools | Clemens Neubauer",
       "url": "https://github.com/cn-tools/cntools_FreshRssExtensions",
       "type": "gh-subdirectory"
@@ -148,6 +148,14 @@
     {
       "name": "FeedTitleBuilder",
       "description": "Build your own feed title based on url, the original feed title and the date the feed was added",
+      "version": 0.1,
+      "author": "CNTools | Clemens Neubauer",
+      "url": "https://github.com/cn-tools/cntools_FreshRssExtensions",
+      "type": "gh-subdirectory"
+    },
+    {
+      "name": "Copy2Clipboard",
+      "description": "Add a button in the navigation bar to copy the destination links of all visible entries into clipboard",
       "version": 0.1,
       "author": "CNTools | Clemens Neubauer",
       "url": "https://github.com/cn-tools/cntools_FreshRssExtensions",


### PR DESCRIPTION
### Link to the new extension [Copy 2 Clipboard](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-Copy2Clipboard):

This add on for FreshRSS add a button in the navigation bar to copy the destination links of all visible entries into clipboard.
Required FreshRSS version at least v1.18


### Link to the extension [YouTube Channel 2 RSSFeed](https://github.com/cn-tools/cntools_FreshRssExtensions/tree/master/xExtension-YouTubeChannel2RssFeed):

Bump version