### PR TITLE
Add new Explosm extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,3 +59,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@Kapdap](https://github.com/Kapdap)
 
 * [Clickable Links](https://github.com/kapdap/freshrss-extensions/tree/master/xExtension-ClickableLinks): Replaces non-clickable plain text URLs found in articles with clickable HTML links
+
+### By [@dohseven](https://framagit.org/dohseven)
+
+* [Explosm](https://framagit.org/dohseven/freshrss-explosm): Directly displays the Explosm comic in FreshRSS

--- a/extensions.json
+++ b/extensions.json
@@ -208,6 +208,14 @@
       "author": "Kapdap",
       "url": "https://github.com/Kapdap/freshrss-extensions",
       "type": "gh-subdirectory"
+    },
+    {
+      "name": "Explosm Daily Comic",
+      "version": "0.1.0",
+      "description": "Embed the images from Explosm daily feed inside article content.",
+      "author": "dohseven",
+      "url": "https://framagit.org/dohseven/freshrss-explosm",
+      "type": "gh-subdirectory"
     }
   ]
 }


### PR DESCRIPTION
Add a new [Explosm extension](https://framagit.org/dohseven/freshrss-explosm), which is able to retrieve the Explosm comic to display it directly in FreshRSS.