### PR TITLE
xExtension-YouTube update

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ There are some FreshRSS extensions out there, developed by community members:
 
 ### By [@kevinpapst](https://github.com/kevinpapst), [Web](https://www.kevinpapst.de/)
 
-* [Youtube/Peertube](https://github.com/kevinpapst/freshrss-youtube): Display videos from YouTube/PeerTube feeds inline
 * [Dilbert](https://github.com/kevinpapst/freshrss-dilbert): Display your daily Dilbert comic in FreshRSS directly
 * [Teem](https://github.com/kevinpapst/freshrss-teem): Display videos from the skydiving website jointheteem.com inline
 
@@ -63,3 +62,8 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@dohseven](https://framagit.org/dohseven)
 
 * [Explosm](https://framagit.org/dohseven/freshrss-explosm): Directly displays the Explosm comic in FreshRSS
+
+
+### By [@ImAReplicant](https://framagit.org/ImAReplicant)
+
+* [Youtube/Peertube](https://framagit.org/ImAReplicant/freshrss-youtube): Display videos from YouTube/PeerTube feeds inline

--- a/extensions.json
+++ b/extensions.json
@@ -322,12 +322,12 @@
         },
         {
             "name": "YouTube/PeerTube Video Feed",
-            "author": "Kevin Papst",
+            "author": "ImAReplicant (forked from Kevin Papst)",
             "description": "Embed YouTube/PeerTube feeds inside article content.",
-            "version": 0.1,
+            "version": 0.11,
             "entrypoint": "YouTube",
             "type": "user",
-            "url": "https://github.com/kevinpapst/freshrss-youtube",
+            "url": "https://framagit.org/ImAReplicant/freshrss-youtube",
             "method": "git",
             "directory": "xExtension-YouTube"
         },


### PR DESCRIPTION
Updated the Youtube/Peertube extension to correct the display of Peertube feeds and replace the kevinpapst extension because it is no longer maintained.