### PR TITLE
 GitHub actions considers Pocket button for the extensions.json generation from now

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -46,4 +46,7 @@
 }, {
 	"url": "https://github.com/kapdap/freshrss-extensions",
 	"type": "git"
+}, {
+    "url": "https://github.com/christian-putzke/freshrss-pocket-button",
+    "type": "git"
 }]


### PR DESCRIPTION
Additionally note: Pocket button has no longer a dependency to jQuery.