### PR TITLE
Image Cache Extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,3 +74,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@printfuck](https://github.com/printfuck/)
 
 * [Readable](https://github.com/printfuck/xExtension-Readable): Fetch article content for selected feeds with [Readability](https://github.com/mozilla/readability) or [Mercury](https://github.com/postlight/mercury-parser)
+
+### By [@Victrid](https://github.com/Victrid/)
+
+* [Image Cache](https://github.com/Victrid/freshrss-image-cache-plugin): Cache feed images on your own facility or Cloudflare cache.

--- a/extensions.json
+++ b/extensions.json
@@ -123,6 +123,17 @@
             "directory": "xExtension-GReaderRedate"
         },
         {
+            "name": "Image Cache",
+            "author": "Victrid",
+            "description": "Cache feed images on your own facility or Cloudflare cache.",
+	        "version": 0.2,
+            "entrypoint": "ImageCache",
+            "type": "user",
+            "url": "https://github.com/Victrid/freshrss-image-cache-plugin",
+            "method": "git",
+            "directory": "."
+        },
+        {
             "name": "Image Proxy",
             "author": "Frans de Jonge",
             "description": "No insecure content warnings or disappearing images.",

--- a/repositories.json
+++ b/repositories.json
@@ -52,4 +52,7 @@
 }, {
 	"url": "https://github.com/printfuck/xExtension-Readable",
 	"type": "git"
+}, {
+	"url": "https://github.com/Victrid/freshrss-image-cache-plugin",
+	"type": "git"
 }]


### PR DESCRIPTION
This is an extension for image caching.

Different to Image Proxy plugin, this plugin will notify the cache server to download images when it receives feed entries, and it will be faster to load the picture if the cache server already has the image. While cache missed, this can also function as ImageProxy plugin does.

We also have a cloudflare worker as the example implementation of the cache server, which will utilize the cloudflare cache API so the cached images will be delivered by cloudflare CDN. It can be hosted on cloudflare for free.

Not only solving the http/https degrade problem, users can implement their own cache server or modify the example implementation to fetch images with additional headers, and different user agent, as some RSS feeds may have misconfigured policies on image hotlinking.