### PR TITLE
Add RedditSub as a Third Party Extension in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,8 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@aidistan](https://github.com/aidistan)
 
 * [SyncWithSystemTheme](https://github.com/aidistan/freshrss-extensions/tree/master/xExtension-SyncWithSystemTheme): Synchronize the theme mode with your system.
+
+### By [@balthisar](https://github.com/balthisar)
+
+* [RedditSub](https://github.com/balthisar/xExtension-RedditSub): A FreshRSS Extension to Show a Reddit Subreddit as Part of the Article Title.
+


### PR DESCRIPTION
As the headline indicates, added a link to my extension, which does as depicted in the screenshot:

<img width="911" alt="image" src="https://user-images.githubusercontent.com/3053246/191952103-7b4ec760-5dd6-4160-a2d0-52709fad195d.png">
