### PR TITLE
Add AutoTTL extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@balthisar](https://github.com/balthisar)
 
 * [RedditSub](https://github.com/balthisar/xExtension-RedditSub): A FreshRSS Extension to Show a Reddit Subreddit as Part of the Article Title.
+
+### By [@mgnsk](https://github.com/mgnsk)
+
+* [AutoTTL](https://github.com/mgnsk/FreshRSS-AutoTTL): A FreshRSS extension for automatic feed refresh TTL based on the average frequency of entries.

--- a/repositories.json
+++ b/repositories.json
@@ -61,4 +61,7 @@
 }, {
 	"url": "https://github.com/aidistan/freshrss-extensions",
 	"type": "git"
+}, {
+	"url": "https://github.com/mgnsk/FreshRSS-AutoTTL",
+	"type": "git"
 }]


### PR DESCRIPTION
This is an extension that leverages the `feed_before_actualize` hook to skip refreshing feeds that most likely don't have any new items based on the average frequency of entries.

![Screenshot 2023-02-03 at 17-47-56 Extensions · FreshRSS](https://user-images.githubusercontent.com/15255910/216646499-90e31bfb-c372-4dc8-8bf8-70e61b67fd29.png)

Open to any suggestions.