### PR TITLE
Add News Assistant extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -429,6 +429,17 @@
             "url": "https://github.com/cn-tools/cntools_FreshRssExtensions",
             "method": "git",
             "directory": "xExtension-YouTubeChannel2RssFeed"
+        },
+        {
+            "name": "News Assistant",
+            "author": "Mervyn Zhan",
+            "description": "Use the api of OpenAI to summary the news.",
+            "version": 0.1,
+            "entrypoint": "NewsAssistant",
+            "type": "system",
+            "url": "https://github.com/reply2future/xExtension-NewsAssistant",
+            "method": "git",
+            "directory": "xExtension-NewsAssistant"
         }
     ]
 }

--- a/repositories.json
+++ b/repositories.json
@@ -67,4 +67,7 @@
 }, {
 	"url": "https://github.com/DevonHess/FreshRSS-Extensions",
 	"type": "git"
+}, {
+	"url": "https://github.com/reply2future/xExtension-NewsAssistant",
+	"type": "git"
 }]


### PR DESCRIPTION
Use the api of OpenAI to summary the news.

Thanks for `chatGPT` to help me finishing it.