### PR TITLE
Fix & improve Reading time extension

### DIFF
--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -1,6 +1,6 @@
 Extension pour FreshRSS (https://github.com/FreshRSS)
 
-**v1.2**
+**v1.3**
 
 Source: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime
 
@@ -17,7 +17,7 @@ Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. 
 
 Extension for FressRSS (https://github.com/FreshRSS)
 
-**v1.2**
+**v1.3**
 
 Source: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime
 

--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -11,7 +11,7 @@ S'installe comme toute les extensions, soit via l'outil intégré dans l'interfa
 Aucune module externe. Une fois activée dans les préférences, l'extension doit fonctionner après avoir recharger la page.
 
 Un indicateur du temps de lecture doit s'afficher dans le nom du flux de chaque article.
-Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. À changer si besoin ici: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L24
+Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. À changer si besoin ici: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26
 
 ---
 
@@ -28,7 +28,7 @@ Install it the same way as any other extension, with the integrated tool in the 
 No external module. Once activated in the preferences, this extension should be working after reloading the page.
 
 A reading time
-For the moment the reading speed is manualy set to 300 words/min. If necessary, change it there: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L24
+For the moment the reading speed is manualy set to 300 words/min. If necessary, change it there: https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26
 
 
 

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ReadingTime",
 	"author": "Lapineige",
 	"description": "Add a reading time estimation next to each article",
-	"version": 1.2,
+	"version": 1.3,
 	"entrypoint": "ReadingTime",
 	"type": "user"
 }

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -1,7 +1,7 @@
 {
 	"name": "ReadingTime",
 	"author": "Lapineige",
-	"description": "Add a reading time estimation next to each article title",
+	"description": "Add a reading time estimation next to each article",
 	"version": 1.2,
 	"entrypoint": "ReadingTime",
 	"type": "user"

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -27,19 +27,17 @@
 
         flux_list[i].dataset.readingTime = reading_time.reading_time;
 
-         if (document.body.clientWidth <= 840) { // in mobile mode, the feed name is not visible (there is only the favicon)
-             // add the reading time right before article's title
-             // in that case, [Time] - [Title] format is used instead of a "|" (as it looks better and doesn't take much more space)
-             if ( document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.title a").textContent.substring(0,(reading_time.reading_time + 'm - ').length) != reading_time.reading_time + 'm - ' ) {
-                 document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.title a").textContent = reading_time.reading_time + 'm - ' + document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.title a").textContent;
-             }
-         } else {
-             // add the reading time just after the feed name
-             if ( document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.website").textContent.substring(1, (reading_time.reading_time + 'm|').length + 1) != reading_time.reading_time + 'm|' ) {
-                 document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.website").childNodes[0].childNodes[2].textContent = reading_time.reading_time + 'm| ' + document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list li.item.website").childNodes[0].childNodes[2].textContent;
-             }
-         }
-
+        const li = document.createElement("li");
+        li.setAttribute("class", "item date");
+        li.style.width = "min-content";
+        li.style.minWidth = "40px";
+        li.style.overflow = "hidden";
+        li.style.textAlign = "right";
+        li.style.display = "table-cell";
+        li.textContent = "" + reading_time.reading_time + '\u2009m';
+ 
+        const ul = document.querySelector("#" + reading_time.flux.id + " ul.horizontal-list");
+        ul.insertBefore(li, ul.children[ul.children.length - 1]);
      }
  },
 

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -16,16 +16,16 @@
 
      for (var i = 0; i < flux_list.length; i++) {
 
-         if ("readingTime" in flux_list[i].dataset) {
-             continue;
-         }
+        if ("readingTime" in flux_list[i].dataset) {
+            continue;
+        }
 
-         reading_time.flux = flux_list[i];
+        reading_time.flux = flux_list[i];
 
-         reading_time.words_count = reading_time.flux_words_count(flux_list[i]); // count the words
-         reading_time.reading_time = reading_time.calc_read_time(reading_time.words_count, 300); // change this number (in words) to your prefered reading speed
+        reading_time.words_count = reading_time.flux_words_count(flux_list[i]); // count the words
+        reading_time.reading_time = reading_time.calc_read_time(reading_time.words_count, 300); // change this number (in words) to your prefered reading speed
 
-         flux_list[i].dataset.readingTime = reading_time.reading_time;
+        flux_list[i].dataset.readingTime = reading_time.reading_time;
 
          if (document.body.clientWidth <= 840) { // in mobile mode, the feed name is not visible (there is only the favicon)
              // add the reading time right before article's title
@@ -45,20 +45,20 @@
 
  flux_words_count: function flux_words_count(flux) {
 
-     reading_time.textContent = flux.querySelector('.flux_content .content').textContent; // get textContent, from the article itself (not the header, not the bottom line).
+    reading_time.textContent = flux.querySelector('.flux_content .content').textContent; // get textContent, from the article itself (not the header, not the bottom line).
 
-     // split the text to count the words correctly (source: http://www.mediacollege.com/internet/javascript/text/count-words.html)
-     reading_time.textContent = reading_time.textContent.replace(/(^\s*)|(\s*$)/gi,"");//exclude  start and end white-space
-     reading_time.textContent = reading_time.textContent.replace(/[ ]{2,}/gi," ");//2 or more space to 1
-     reading_time.textContent = reading_time.textContent.replace(/\n /,"\n"); // exclude newline with a start spacing
+    // split the text to count the words correctly (source: http://www.mediacollege.com/internet/javascript/text/count-words.html)
+    reading_time.textContent = reading_time.textContent.replace(/(^\s*)|(\s*$)/gi,"");//exclude  start and end white-space
+    reading_time.textContent = reading_time.textContent.replace(/[ ]{2,}/gi," ");//2 or more space to 1
+    reading_time.textContent = reading_time.textContent.replace(/\n /,"\n"); // exclude newline with a start spacing
 
-     return reading_time.textContent.split(' ').length;
+    return reading_time.textContent.split(' ').length;
  },
 
  calc_read_time : function calc_read_time(wd_count, speed) {
-     reading_time.read_time = Math.round(wd_count/speed);
-     if (reading_time.read_time === 0) { reading_time.read_time = '<1'; }
-     return reading_time.read_time;
+    reading_time.read_time = Math.round(wd_count/speed);
+    if (reading_time.read_time === 0) { reading_time.read_time = '<1'; }
+    return reading_time.read_time;
  },
     };
 


### PR DESCRIPTION
As reported by @svemoe in #148, the Reading time extension doesn't work any more, beginning with 1.20.
The fix would be relatively easy, by just changing the `querySelector`.

However, I'd suggest further improvement of the plugin, by not just injecting the reading time in front of the feed name, but instead adding a separate column for it.

Looks like this with the standard theme in regular view. Notice the second to last column:
![grafik](https://user-images.githubusercontent.com/423373/232510625-429ed1de-1902-44ab-a4a0-73acacbf234a.png)

And like this in mobile view:
![grafik](https://user-images.githubusercontent.com/423373/232510895-eea9ac1b-01ab-4eaa-b1e6-a08e4feec586.png)

I also tested it with other themes, without a problem.