### PR TITLE
Make extensions use typed methods Minz_Request::paramString and Minz_Session::paramString

### DIFF
--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class CustomCSSExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();

--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -30,7 +30,7 @@ class CustomCSSExtension extends Minz_Extension {
 			$tmpPath = explode(EXTENSIONS_PATH . '/', $filepath);
 			$this->permission_problem = $tmpPath[1];
 		} else if (Minz_Request::isPost()) {
-			$css_rules = html_entity_decode(Minz_Request::param('css-rules', ''));
+			$css_rules = html_entity_decode(Minz_Request::paramString('css-rules'));
 			file_put_contents($filepath, $css_rules);
 		}
 

--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -6,7 +6,7 @@ class CustomCSSExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();
 
-		$current_user = Minz_Session::param('currentUser');
+		$current_user = Minz_Session::paramString('currentUser');
 		$filename =  'style.' . $current_user . '.css';
 		$filepath = join_path($this->getPath(), 'static', $filename);
 
@@ -18,7 +18,7 @@ class CustomCSSExtension extends Minz_Extension {
 	public function handleConfigureAction() {
 		$this->registerTranslates();
 
-		$current_user = Minz_Session::param('currentUser');
+		$current_user = Minz_Session::paramString('currentUser');
 		$filename =  'style.' . $current_user . '.css';
 		$staticPath = join_path($this->getPath(), 'static');
 		$filepath = join_path($staticPath, $filename);

--- a/xExtension-CustomCSS/metadata.json
+++ b/xExtension-CustomCSS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom CSS",
 	"author": "Marien Fressinaud",
 	"description": "Give possibility to overwrite the CSS with a user-specific rules.",
-	"version": "0.2",
+	"version": "0.3",
 	"entrypoint": "CustomCSS",
 	"type": "user"
 }

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -6,7 +6,7 @@ class CustomJSExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();
 
-		$current_user = Minz_Session::param('currentUser');
+		$current_user = Minz_Session::paramString('currentUser');
 		$filename =  'script.' . $current_user . '.js';
 		$filepath = join_path($this->getPath(), 'static', $filename);
 
@@ -18,7 +18,7 @@ class CustomJSExtension extends Minz_Extension {
 	public function handleConfigureAction() {
 		$this->registerTranslates();
 
-		$current_user = Minz_Session::param('currentUser');
+		$current_user = Minz_Session::paramString('currentUser');
 		$filename =  'script.' . $current_user . '.js';
 		$staticPath = join_path($this->getPath(), 'static');
 		$filepath = join_path($staticPath, $filename);

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class CustomJSExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -30,7 +30,7 @@ class CustomJSExtension extends Minz_Extension {
 			$tmpPath = explode(EXTENSIONS_PATH . '/', $filepath);
 			$this->permission_problem = $tmpPath[1];
 		} else if (Minz_Request::isPost()) {
-			$js_rules = html_entity_decode(Minz_Request::param('js-rules', ''));
+			$js_rules = html_entity_decode(Minz_Request::paramString('js-rules'));
 			file_put_contents($filepath, $js_rules);
 		}
 

--- a/xExtension-CustomJS/metadata.json
+++ b/xExtension-CustomJS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom JS",
 	"author": "Frans de Jonge",
 	"description": "Apply custom JS.",
-	"version": "0.2",
+	"version": "0.3",
 	"entrypoint": "CustomJS",
 	"type": "user"
 }

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ImageProxyExtension extends Minz_Extension {
 	// Defaults
 	const PROXY_URL = 'https://images.weserv.nl/?url=';

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -54,12 +54,12 @@ class ImageProxyExtension extends Minz_Extension {
 		$this->registerTranslates();
 
 		if (Minz_Request::isPost()) {
-			FreshRSS_Context::$user_conf->image_proxy_url = Minz_Request::param('image_proxy_url', self::PROXY_URL, true);
-			FreshRSS_Context::$user_conf->image_proxy_scheme_http = Minz_Request::param('image_proxy_scheme_http', '');
-			FreshRSS_Context::$user_conf->image_proxy_scheme_https = Minz_Request::param('image_proxy_scheme_https', '');
-			FreshRSS_Context::$user_conf->image_proxy_scheme_default = Minz_Request::param('image_proxy_scheme_default', self::SCHEME_DEFAULT);
-			FreshRSS_Context::$user_conf->image_proxy_scheme_include = Minz_Request::param('image_proxy_scheme_include', '');
-			FreshRSS_Context::$user_conf->image_proxy_url_encode = Minz_Request::param('image_proxy_url_encode', '');
+			FreshRSS_Context::$user_conf->image_proxy_url = Minz_Request::paramString('image_proxy_url', true) ?: self::PROXY_URL;
+			FreshRSS_Context::$user_conf->image_proxy_scheme_http = Minz_Request::paramString('image_proxy_scheme_http');
+			FreshRSS_Context::$user_conf->image_proxy_scheme_https = Minz_Request::paramString('image_proxy_scheme_https');
+			FreshRSS_Context::$user_conf->image_proxy_scheme_default = Minz_Request::paramString('image_proxy_scheme_default') ?: self::SCHEME_DEFAULT;
+			FreshRSS_Context::$user_conf->image_proxy_scheme_include = Minz_Request::paramString('image_proxy_scheme_include');
+			FreshRSS_Context::$user_conf->image_proxy_url_encode = Minz_Request::paramString('image_proxy_url_encode');
 			FreshRSS_Context::$user_conf->save();
 		}
 	}

--- a/xExtension-ImageProxy/metadata.json
+++ b/xExtension-ImageProxy/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Image Proxy",
 	"author": "Frans de Jonge",
 	"description": "No insecure content warnings or disappearing images.",
-	"version": "0.5",
+	"version": "0.6",
 	"entrypoint": "ImageProxy",
 	"type": "user"
 }

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class QuickCollapseExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 class ReadingTimeExtension extends Minz_Extension {
 	public function init() {
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));

--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class ShareByEmailExtension extends Minz_Extension {
 	public function init() {
 		$this->registerTranslates();

--- a/xExtension-StickyFeeds/extension.php
+++ b/xExtension-StickyFeeds/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class StickyFeedsExtension extends Minz_Extension {
 	public function init() {
 		Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TTRSS_APIExtension extends Minz_Extension {
 	public function init() {
 		$this->registerHook('post_update',

--- a/xExtension-TitleWrap/extension.php
+++ b/xExtension-TitleWrap/extension.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 class TitleWrapExtension extends Minz_Extension {
 	public function init() {
                 Minz_View::appendStyle($this->getFileUrl('title_wrap.css', 'css'));

--- a/xExtension-showFeedID/extension.php
+++ b/xExtension-showFeedID/extension.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 class ShowFeedIdExtension extends Minz_Extension {
 	public function init() {
 		Minz_View::appendScript($this->getFileUrl('showfeedid.js', 'js'));


### PR DESCRIPTION
As per short discussion in PR [#5830](https://github.com/FreshRSS/FreshRSS/pull/5830):

https://github.com/FreshRSS/FreshRSS/pull/5830#issuecomment-1816813504
https://github.com/FreshRSS/FreshRSS/pull/5830#issuecomment-1817137233

Tested the 3 extensions with actual changes in docker container running `d2aef84827ee freshrss/freshrss:edge`:

- xExtension-CustomJS
- xExtension-CustomCSS
- xExtension-ImageProxy