### PR TITLE
Fix for issue #183: xExtension-ColorfulList not working when only viewing unread messages 

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,9 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@rudism](https://code.sitosis.com/rudism)
 
 * [Kagi Summarizer](https://code.sitosis.com/rudism/freshrss-kagi-summarizer): Adds a "Summarize" button to the top of all entries that will fetch the summary of the entry using the [Kagi Universal Summarizer](https://kagi.com/summarizer/index.html).
+
+
+### By [@shinemoon](https://github.com/shinemoon]
+
+* [Colorful List](https://github.com/shinemoon/FreshRSS-Dev/tree/master/extensions/xExtension-ColorfulList): Generate light different background color for article list rows (relying on the feed name)
+

--- a/xExtension-ColorfulList/metadata.json
+++ b/xExtension-ColorfulList/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Colorful List",
 	"author": "Claud Xiao",
 	"description": "Colorful Entry Title based on RSS source",
-	"version": 0.1,
+	"version": 0.2,
 	"entrypoint": "ColorfulList",
 	"type": "user"
 }

--- a/xExtension-ColorfulList/static/script.js
+++ b/xExtension-ColorfulList/static/script.js
@@ -1,23 +1,29 @@
+
+
 document.addEventListener('DOMContentLoaded', function(){
-    function monitorEntry(monitorCallback) {
-        const targetNode = document.getElementById('stream');
-        const config = { attributes: false, childList: true, subtree: false};
-        const callback = function(mutationsList, observer) {
-            for(let mutation of mutationsList) {
-                if (mutation.type === 'childList') {
-                    monitorCallback(mutationsList);
-                }
-                    }
-        };
-        const observer = new MutationObserver(callback);
-        observer.observe(targetNode, config);
-        //observer.disconnect();
-    };
+    //Initial Colorize for situation where 'no new item changes triggered later' (https://github.com/FreshRSS/Extensions/issues/183)
+    colorize();
+
+    //Insert entry monitor
     monitorEntry(colorize);
 });
 
+function monitorEntry(monitorCallback) {
+    const targetNode = document.getElementById('stream');
+    const config = { attributes: false, childList: true, subtree: false};
+    const callback = function(mutationsList, observer) {
+        for(let mutation of mutationsList) {
+            if (mutation.type === 'childList') {
+                monitorCallback(mutationsList);
+            }
+        }
+    };
+    const observer = new MutationObserver(callback);
+    observer.observe(targetNode, config);
+    //observer.disconnect();
+};
 
-function colorize(entries){
+function colorize(){
     let entry = document.querySelectorAll('.flux_header');
     entry.forEach((e,i)=>{
         let cl = stringToColour(e.querySelector('.website').textContent)+'12';


### PR DESCRIPTION
Colorization will not be triggered while in some scenario the loaded page will not have any 'new' DOM structure change, and one 'init' colorization can solve this.