### PR TITLE
ImageProxy: avoid oversight of wrapping an entire HTML document around image

### DIFF
--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -121,7 +121,7 @@ final class ImageProxyExtension extends Minz_Extension {
 
 		$doc = new DOMDocument();
 		libxml_use_internal_errors(true); // prevent tag soup errors from showing
-		$doc->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'));
+		$doc->loadHTML(mb_convert_encoding($content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
 		$imgs = $doc->getElementsByTagName('img');
 		foreach ($imgs as $img) {
 			if ($img->hasAttribute('src')) {


### PR DESCRIPTION


In reply to <https://github.com/FreshRSS/Extensions/issues/206#issuecomment-1976649551>.

With special thanks to this comment: <https://www.php.net/manual/en/domdocument.savehtml.php#119767>