### PR TITLE
Fix deprecated GitHub Actions

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -27,7 +27,7 @@ jobs:
         id: diff
         run: |
           DIFF=$(git diff --numstat -- $FILE | wc -l)
-          echo "::set-output name=DIFF::$DIFF"
+          echo "DIFF=$DIFF" >> $GITHUB_OUTPUT
 
       - name: Commit changes
         run: |


### PR DESCRIPTION
fix https://github.com/FreshRSS/Extensions/issues/219
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
