### PR TITLE
make sure both versions are equal

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -509,10 +509,10 @@
             "directory": "."
         },
         {
-            "name": "YouTube/PeerTube Video Feed",
+            "name": "YouTube Video Feed",
             "author": "Kevin Papst",
-            "description": "Embed YouTube/PeerTube feeds inside article content.",
-            "version": "0.1",
+            "description": "Embed YouTube feeds inside article content.",
+            "version": "0.10",
             "entrypoint": "YouTube",
             "type": "user",
             "url": "https://github.com/FreshRSS/Extensions",

--- a/xExtension-YouTube/metadata.json
+++ b/xExtension-YouTube/metadata.json
@@ -1,8 +1,8 @@
 {
-	"name": "YouTube/PeerTube Video Feed",
+	"name": "YouTube Video Feed",
 	"author": "Kevin Papst",
-	"description": "Embed YouTube/PeerTube feeds inside article content.",
-	"version": 0.10,
+	"description": "Embed YouTube feeds inside article content.",
+	"version": "0.10",
 	"entrypoint": "YouTube",
 	"type": "user"
 }


### PR DESCRIPTION
- due to the previous version being an "int" (in metadata.json) we cannot see on screenshots if someone really updated to the latest release or is still using an old version.
- aligned description and title in both files
- remove peer tube reference, as I never used or tested that and never wanted to support it either ... I don't even know what that is or if anyone uses it