### PR TITLE
New developer command to test all third-party extensions

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,5 +2,6 @@
 *.min.js
 node_modules/
 symbolic/
+third-party/
 tmp/
 vendor/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@
 bin/
 node_modules/
 symbolic/
+third-party/
 tmp/
 vendor/

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,5 +1,6 @@
 .git/
 node_modules/
 symbolic/
+third-party/
 tmp/
 vendor/

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,5 +1,6 @@
 .git/
 node_modules/
 symbolic/
+third-party/
 tmp/
 vendor/

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -1,5 +1,6 @@
 .git/
 node_modules/
 symbolic/
+third-party/
 tmp/
 vendor/

--- a/.typos.toml
+++ b/.typos.toml
@@ -17,6 +17,7 @@ extend-exclude = [
 	"bin/",
 	"node_modules/",
 	"symbolic/",
+	"third-party/",
 	"tmp/",
 	"vendor/",
 	"xExtension-ReadingTime/README.md"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ To install an extension, download [the extension archive](https://github.com/Fre
 Then, upload the specific extension(s) you want on your server.
 Extensions must be in the `./extensions` directory of your FreshRSS installation.
 
+## Commands for developers
+
+```sh
+# Test this repository and its extensions
+make test-all
+
+# Test compatibility between `../FreshRSS/` core and all known extensions from `./repositories.json`
+./generate.php
+composer run-script phpstan-third-party
+```
+
 ## Third-party extensions
 
 There are some FreshRSS extensions out there, developed by community members:

--- a/composer.json
+++ b/composer.json
@@ -45,13 +45,13 @@
         "ext-pdo_pgsql": "*"
     },
     "require-dev": {
-        "php": ">=8.0",
+        "php": ">=7.4",
         "ext-phar": "*",
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-strict-rules": "^1.5",
-        "squizlabs/php_codesniffer": "^3.7"
+        "squizlabs/php_codesniffer": "^3.9"
     },
     "scripts": {
         "php-lint": "find . -type d -name 'vendor' -prune -o -name '*.php' -print0 | xargs -0 -n1 -P4 php -l 1>/dev/null",
@@ -59,7 +59,8 @@
         "phpcs": "phpcs . -s",
         "phpcbf": "phpcbf . -p -s",
         "phpstan": "phpstan analyse --memory-limit 512M .",
-        "phpstan-next": "phpstan analyse --level 9 --memory-limit 512M $(find . -type d -name 'vendor' -prune -o -name '*.php' -o -name '*.phtml' | grep -Fxvf ./tests/phpstan-next.txt | sort | paste -s -)",
+        "phpstan-next": "phpstan analyse --memory-limit 512M -c phpstan-next.neon .",
+        "phpstan-third-party": "phpstan analyse --memory-limit 512M -c phpstan-third-party.neon .",
         "test": [
             "@php-lint",
             "@phtml-lint",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2c89b2e0c08f09d94faa394270fc16a9",
+    "content-hash": "bf0d2d1a05ed08841ca6bd3e7ec96b74",
     "packages": [],
     "packages-dev": [
         {
             "name": "phpstan/phpstan",
-            "version": "1.10.44",
+            "version": "1.10.66",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b"
+                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/bf84367c53a23f759513985c54ffe0d0c249825b",
-                "reference": "bf84367c53a23f759513985c54ffe0d0c249825b",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/94779c987e4ebd620025d9e5fdd23323903950bd",
+                "reference": "94779c987e4ebd620025d9e5fdd23323903950bd",
                 "shasum": ""
             },
             "require": {
@@ -67,25 +67,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-21T16:30:46+00:00"
+            "time": "2024-03-28T16:17:31+00:00"
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "7a50e9662ee9f3942e4aaaf3d603653f60282542"
+                "reference": "568210bd301f94a0d4b1e5a0808c374c1b9cf11b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/7a50e9662ee9f3942e4aaaf3d603653f60282542",
-                "reference": "7a50e9662ee9f3942e4aaaf3d603653f60282542",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/568210bd301f94a0d4b1e5a0808c374c1b9cf11b",
+                "reference": "568210bd301f94a0d4b1e5a0808c374c1b9cf11b",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10.34"
+                "phpstan/phpstan": "^1.10.60"
             },
             "require-dev": {
                 "nikic/php-parser": "^4.13.0",
@@ -114,22 +114,22 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.5.2"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.5.3"
             },
-            "time": "2023-10-30T14:35:06+00:00"
+            "time": "2024-04-06T07:43:25+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
+            "version": "3.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/267a4405fff1d9c847134db3a3c92f1ab7f77909",
+                "reference": "267a4405fff1d9c847134db3a3c92f1ab7f77909",
                 "shasum": ""
             },
             "require": {
@@ -139,11 +139,11 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
             },
             "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
+                "bin/phpcbf",
+                "bin/phpcs"
             ],
             "type": "library",
             "extra": {
@@ -158,22 +158,45 @@
             "authors": [
                 {
                     "name": "Greg Sherwood",
-                    "role": "lead"
+                    "role": "Former lead"
+                },
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards",
                 "static analysis"
             ],
             "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
-            "time": "2023-02-22T23:07:41+00:00"
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-03-31T21:03:09+00:00"
         }
     ],
     "aliases": [],
@@ -205,10 +228,10 @@
         "ext-zlib": "*"
     },
     "platform-dev": {
-        "php": ">=8.0",
+        "php": ">=7.4",
         "ext-phar": "*",
         "ext-tokenizer": "*",
         "ext-xmlwriter": "*"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/extensions.json
+++ b/extensions.json
@@ -222,6 +222,17 @@
             "directory": "xExtension-Invidious"
         },
         {
+            "name": "Invidious Video Feed",
+            "author": "Paul Tunbridge (forked from Korbak and Kevin Papst)",
+            "description": "Embed YouTube feeds inside article content, but with Invidious.",
+            "version": "1.1",
+            "entrypoint": "Invidious",
+            "type": "user",
+            "url": "https://github.com/tunbridgep/freshrss-invidious",
+            "method": "git",
+            "directory": "xExtension-Invidious"
+        },
+        {
             "name": "Kagi Summarizer",
             "author": "Rudis Muiznieks",
             "description": "Add buttons to summarize articles with the Kagi Universal Summarizer.",

--- a/generate.php
+++ b/generate.php
@@ -6,11 +6,12 @@
 // ------------------- //
 const VERSION = 0.1;
 const TYPE_GIT = 'git';
-$tempFolder = './tmp';
+$tempFolder = './third-party/';
 
 $extensions = [];
 $gitRepositories = [];
 if (file_exists($tempFolder)) {
+	// TODO: Improve by keeping git copy if possible (e.g. fetch + reset)
 	exec("rm -rf -- {$tempFolder}");
 }
 

--- a/phpstan-next.neon
+++ b/phpstan-next.neon
@@ -1,0 +1,10 @@
+includes:
+	- phpstan.neon
+
+parameters:
+	level: 9
+	excludePaths:
+		analyse:
+			- xExtension-ImageProxy/configure.phtml
+			- xExtension-ImageProxy/extension.php
+			- xExtension-TTRSS_API/ttrss.php

--- a/phpstan-third-party.neon
+++ b/phpstan-third-party.neon
@@ -1,0 +1,24 @@
+parameters:
+	level: 0
+	treatPhpDocTypesAsCertain: false
+	fileExtensions:
+		- php
+		- phtml
+	paths:
+		- ../FreshRSS
+		- third-party/
+	excludePaths:
+		analyse:
+			- ../FreshRSS
+			- third-party/*/vendor/*
+		analyseAndScan:
+			- .git/
+			- node_modules/
+			- symbolic/
+			- third-party/*/tests/*
+			- tmp/
+			- vendor/
+			- xExtension-*
+	dynamicConstantNames:
+		- TYPE_GIT
+	reportMaybesInPropertyPhpDocTypes: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,7 @@
 parameters:
 	# TODO: Increase rule-level https://phpstan.org/user-guide/rule-levels
 	level: 1
+	phpVersion: 80399	# TODO: Remove line when moving composer.json to PHP 8+
 	treatPhpDocTypesAsCertain: false
 	fileExtensions:
 		- php
@@ -16,10 +17,11 @@ parameters:
 			- .git/
 			- node_modules/
 			- symbolic/
+			- third-party/
 			- tmp/
-			- xExtension-TTRSS_API/
 	dynamicConstantNames:
 		- TYPE_GIT
+	checkMissingOverrideMethodAttribute: true
 	reportMaybesInPropertyPhpDocTypes: false
 	strictRules:
 		allRules: false

--- a/repositories.json
+++ b/repositories.json
@@ -44,7 +44,7 @@
 	"url": "https://github.com/babico/xExtension-TwitchChannel2RssFeed",
 	"type": "git"
 }, {
-	"url": "thttps://github.com/tunbridgep/freshrss-invidious",
+	"url": "https://github.com/tunbridgep/freshrss-invidious",
 	"type": "git"
 }, {
 	"url": "https://github.com/javerous/freshrss-greader-redate",

--- a/tests/phpstan-next.txt
+++ b/tests/phpstan-next.txt
@@ -1,7 +1,0 @@
-# List of files, which are not yet passing PHPStan level 9 https://phpstan.org/user-guide/rule-levels
-# Used for automated tests to avoid regressions in files already passing that level.
-# Can be regenerated with something like:
-# find . -type d -name 'vendor' -prune -o -name '*.php' -exec sh -c 'vendor/bin/phpstan analyse --level 9 --memory-limit 512M {} >/dev/null 2>/dev/null || echo {}' \;
-
-./xExtension-ImageProxy/configure.phtml
-./xExtension-ImageProxy/extension.php

--- a/xExtension-ColorfulList/extension.php
+++ b/xExtension-ColorfulList/extension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class ColorfulListExtension extends Minz_Extension
 {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('script.js', 'js'));
 	}

--- a/xExtension-ColorfulList/extension.php
+++ b/xExtension-ColorfulList/extension.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-class ColorfulListExtension extends Minz_Extension
+final class ColorfulListExtension extends Minz_Extension
 {
+	#[Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('script.js', 'js'));
 	}

--- a/xExtension-ColorfulList/metadata.json
+++ b/xExtension-ColorfulList/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Colorful List",
 	"author": "Claud Xiao",
 	"description": "Colorful Entry Title based on RSS source",
-	"version": 0.3,
+	"version": "0.3.1",
 	"entrypoint": "ColorfulList",
 	"type": "user"
 }

--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -6,7 +6,7 @@ final class CustomCSSExtension extends Minz_Extension {
 	public string $css_rules;
 	public string $permission_problem = '';
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->registerTranslates();
 
@@ -19,7 +19,7 @@ final class CustomCSSExtension extends Minz_Extension {
 		}
 	}
 
-	#[Override]
+	#[\Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-CustomCSS/extension.php
+++ b/xExtension-CustomCSS/extension.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-class CustomCSSExtension extends Minz_Extension {
+final class CustomCSSExtension extends Minz_Extension {
 	public string $css_rules;
 	public string $permission_problem = '';
 
+	#[Override]
 	public function init(): void {
 		$this->registerTranslates();
 
@@ -18,6 +19,7 @@ class CustomCSSExtension extends Minz_Extension {
 		}
 	}
 
+	#[Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-CustomCSS/metadata.json
+++ b/xExtension-CustomCSS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom CSS",
 	"author": "Marien Fressinaud",
 	"description": "Give possibility to overwrite the CSS with a user-specific rules.",
-	"version": "0.5",
+	"version": "0.5.1",
 	"entrypoint": "CustomCSS",
 	"type": "user"
 }

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
-class CustomJSExtension extends Minz_Extension {
+final class CustomJSExtension extends Minz_Extension {
 	public string $js_rules;
 	public string $permission_problem = '';
 
+	#[Override]
 	public function init(): void {
 		$this->registerTranslates();
 
@@ -18,6 +19,7 @@ class CustomJSExtension extends Minz_Extension {
 		}
 	}
 
+	#[Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-CustomJS/extension.php
+++ b/xExtension-CustomJS/extension.php
@@ -6,7 +6,7 @@ final class CustomJSExtension extends Minz_Extension {
 	public string $js_rules;
 	public string $permission_problem = '';
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->registerTranslates();
 
@@ -19,7 +19,7 @@ final class CustomJSExtension extends Minz_Extension {
 		}
 	}
 
-	#[Override]
+	#[\Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-CustomJS/metadata.json
+++ b/xExtension-CustomJS/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Custom JS",
 	"author": "Frans de Jonge",
 	"description": "Apply custom JS.",
-	"version": "0.5",
+	"version": "0.5.1",
 	"entrypoint": "CustomJS",
 	"type": "user"
 }

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -11,6 +11,7 @@ final class ImageProxyExtension extends Minz_Extension {
 	private const SCHEME_INCLUDE = '';
 	private const URL_ENCODE = '1';
 
+	#[Override]
 	public function init(): void {
 		if (!FreshRSS_Context::hasSystemConf()) {
 			throw new FreshRSS_Context_Exception('System configuration not initialised!');
@@ -55,6 +56,7 @@ final class ImageProxyExtension extends Minz_Extension {
 		}
 	}
 
+	#[Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -11,7 +11,7 @@ final class ImageProxyExtension extends Minz_Extension {
 	private const SCHEME_INCLUDE = '';
 	private const URL_ENCODE = '1';
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		if (!FreshRSS_Context::hasSystemConf()) {
 			throw new FreshRSS_Context_Exception('System configuration not initialised!');
@@ -53,7 +53,7 @@ final class ImageProxyExtension extends Minz_Extension {
 		}
 	}
 
-	#[Override]
+	#[\Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 

--- a/xExtension-ImageProxy/extension.php
+++ b/xExtension-ImageProxy/extension.php
@@ -16,10 +16,7 @@ final class ImageProxyExtension extends Minz_Extension {
 		if (!FreshRSS_Context::hasSystemConf()) {
 			throw new FreshRSS_Context_Exception('System configuration not initialised!');
 		}
-		$this->registerHook(
-			'entry_before_display',
-			array('ImageProxyExtension', 'setImageProxyHook')
-		);
+		$this->registerHook('entry_before_display', [self::class, 'setImageProxyHook']);
 		// Defaults
 		$save = false;
 		if (is_null(FreshRSS_Context::userConf()->image_proxy_url)) {

--- a/xExtension-ImageProxy/metadata.json
+++ b/xExtension-ImageProxy/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Image Proxy",
 	"author": "Frans de Jonge",
 	"description": "No insecure content warnings or disappearing images.",
-	"version": "0.7.1",
+	"version": "0.7.2",
 	"entrypoint": "ImageProxy",
 	"type": "user"
 }

--- a/xExtension-QuickCollapse/Controllers/quickCollapseController.php
+++ b/xExtension-QuickCollapse/Controllers/quickCollapseController.php
@@ -1,6 +1,7 @@
 <?php
+declare(strict_types=1);
 
-class FreshExtension_quickCollapse_Controller extends Minz_ActionController {
+final class FreshExtension_quickCollapse_Controller extends Minz_ActionController {
 
 	/** @var QuickCollapse\View */
 	protected $view;

--- a/xExtension-QuickCollapse/Models/View.php
+++ b/xExtension-QuickCollapse/Models/View.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace QuickCollapse;
 
-class View extends \Minz_View {
+final class View extends \Minz_View {
 
 	public string $icon_url_in = '';
 	public string $icon_url_out = '';

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-class QuickCollapseExtension extends Minz_Extension {
+final class QuickCollapseExtension extends Minz_Extension {
+	#[Override]
 	public function init(): void {
 		$this->registerTranslates();
 		$this->registerViews();

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 final class QuickCollapseExtension extends Minz_Extension {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->registerTranslates();
 		$this->registerViews();

--- a/xExtension-QuickCollapse/metadata.json
+++ b/xExtension-QuickCollapse/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Quick Collapse",
 	"author": "romibi and Marien Fressinaud",
 	"description": "Quickly change from folded to unfolded articles",
-	"version": "0.2",
+	"version": "0.2.1",
 	"entrypoint": "QuickCollapse",
 	"type": "user"
 }

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 final class ReadingTimeExtension extends Minz_Extension {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
 	}

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-class ReadingTimeExtension extends Minz_Extension {
+final class ReadingTimeExtension extends Minz_Extension {
+	#[Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
 	}

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ReadingTime",
 	"author": "Lapineige",
 	"description": "Add a reading time estimation next to each article",
-	"version": "1.5",
+	"version": "1.5.1",
 	"entrypoint": "ReadingTime",
 	"type": "user"
 }

--- a/xExtension-ShareByEmail/Controllers/shareByEmailController.php
+++ b/xExtension-ShareByEmail/Controllers/shareByEmailController.php
@@ -12,7 +12,7 @@ final class FreshExtension_shareByEmail_Controller extends Minz_ActionController
 		parent::__construct(ShareByEmail\mailers\View::class);
 	}
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->extension = Minz_ExtensionManager::findExtension('Share By Email');
 	}

--- a/xExtension-ShareByEmail/Controllers/shareByEmailController.php
+++ b/xExtension-ShareByEmail/Controllers/shareByEmailController.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-class FreshExtension_shareByEmail_Controller extends Minz_ActionController {
+final class FreshExtension_shareByEmail_Controller extends Minz_ActionController {
 	public ?Minz_Extension $extension;
 
 	/** @var ShareByEmail\mailers\View */
@@ -12,6 +12,7 @@ class FreshExtension_shareByEmail_Controller extends Minz_ActionController {
 		parent::__construct(ShareByEmail\mailers\View::class);
 	}
 
+	#[Override]
 	public function init(): void {
 		$this->extension = Minz_ExtensionManager::findExtension('Share By Email');
 	}
@@ -34,13 +35,13 @@ class FreshExtension_shareByEmail_Controller extends Minz_ActionController {
 		}
 		$this->view->entry = $entry;
 
-		if (FreshRSS_Context::$system_conf === null) {
+		if (!FreshRSS_Context::hasSystemConf()) {
 			throw new FreshRSS_Context_Exception('System configuration not initialised!');
 		}
 
 		$username = Minz_Session::paramString('currentUser') ?: '_';
-		$service_name = FreshRSS_Context::$system_conf->title;
-		$service_url = FreshRSS_Context::$system_conf->base_url;
+		$service_name = FreshRSS_Context::systemConf()->title;
+		$service_url = FreshRSS_Context::systemConf()->base_url;
 
 		Minz_View::prependTitle(_t('shareByEmail.share.title') . ' · ');
 		if ($this->extension !== null) {

--- a/xExtension-ShareByEmail/Models/View.php
+++ b/xExtension-ShareByEmail/Models/View.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace ShareByEmail\mailers;
 
-class View extends \Minz_View {
+final class View extends \Minz_View {
 
 	public ?\FreshRSS_Entry $entry = null;
 	public string $content = '';

--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-class ShareByEmailExtension extends Minz_Extension {
+final class ShareByEmailExtension extends Minz_Extension {
 
+	#[Override]
 	public function init(): void {
 		$this->registerTranslates();
 

--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 final class ShareByEmailExtension extends Minz_Extension {
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->registerTranslates();
 

--- a/xExtension-ShareByEmail/mailers/Share.php
+++ b/xExtension-ShareByEmail/mailers/Share.php
@@ -18,8 +18,8 @@ final class Share extends \Minz_Mailer {
 
 		$this->view->content = $content;
 
-		if (isset(\FreshRSS_Context::$system_conf)) {
-			$subject_prefix = '[' . \FreshRSS_Context::$system_conf->title . ']';
+		if (\FreshRSS_Context::hasSystemConf()) {
+			$subject_prefix = '[' . \FreshRSS_Context::systemConf()->title . ']';
 		} else {
 			$subject_prefix = '';
 		}

--- a/xExtension-ShareByEmail/metadata.json
+++ b/xExtension-ShareByEmail/metadata.json
@@ -2,7 +2,7 @@
   "name": "Share By Email",
   "author": "Marien Fressinaud",
   "description": "Improve the sharing by email system.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "entrypoint": "ShareByEmail",
   "type": "user"
 }

--- a/xExtension-StickyFeeds/extension.php
+++ b/xExtension-StickyFeeds/extension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 final class StickyFeedsExtension extends Minz_Extension {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));
 		Minz_View::appendScript($this->getFileUrl('script.js', 'js'));

--- a/xExtension-StickyFeeds/extension.php
+++ b/xExtension-StickyFeeds/extension.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-class StickyFeedsExtension extends Minz_Extension {
+final class StickyFeedsExtension extends Minz_Extension {
+	#[Override]
 	public function init(): void {
 		Minz_View::appendStyle($this->getFileUrl('style.css', 'css'));
 		Minz_View::appendScript($this->getFileUrl('script.js', 'js'));

--- a/xExtension-StickyFeeds/metadata.json
+++ b/xExtension-StickyFeeds/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Sticky Feeds",
 	"author": "Marien Fressinaud",
 	"description": "Set the feed aside in the main stream following the window scroll.",
-	"version": "0.2",
+	"version": "0.2.1",
 	"entrypoint": "StickyFeeds",
 	"type": "user"
 }

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -1,14 +1,17 @@
 <?php
 declare(strict_types=1);
 
-class TTRSS_APIExtension extends Minz_Extension {
-	public function init() {
+final class TTRSS_APIExtension extends Minz_Extension {
+
+	#[Override]
+	public function init(): void {
 		$this->registerHook(
 			'post_update',
 			array($this, 'postUpdateHook')
 		);
 	}
 
+	#[Override]
 	public function install() {
 		$filename = 'ttrss.php';
 		$file_source = join_path($this->getPath(), $filename);
@@ -36,6 +39,7 @@ class TTRSS_APIExtension extends Minz_Extension {
 		return true;
 	}
 
+	#[Override]
 	public function uninstall() {
 		$filename = 'ttrss.php';
 		$file_destination = join_path(PUBLIC_PATH, 'api', $filename);
@@ -47,7 +51,7 @@ class TTRSS_APIExtension extends Minz_Extension {
 		return true;
 	}
 
-	public function postUpdateHook() {
+	public function postUpdateHook(): void {
 		$res = $this->install();
 
 		if ($res !== true) {

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -3,12 +3,12 @@ declare(strict_types=1);
 
 final class TTRSS_APIExtension extends Minz_Extension {
 
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		$this->registerHook('post_update', [$this, 'postUpdateHook']);
 	}
 
-	#[Override]
+	#[\Override]
 	public function install() {
 		$filename = 'ttrss.php';
 		$file_source = join_path($this->getPath(), $filename);
@@ -36,7 +36,7 @@ final class TTRSS_APIExtension extends Minz_Extension {
 		return true;
 	}
 
-	#[Override]
+	#[\Override]
 	public function uninstall() {
 		$filename = 'ttrss.php';
 		$file_destination = join_path(PUBLIC_PATH, 'api', $filename);

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -5,7 +5,7 @@ final class TTRSS_APIExtension extends Minz_Extension {
 
 	#[Override]
 	public function init(): void {
-		$this->registerHook('post_update', [self::class, 'postUpdateHook']);
+		$this->registerHook('post_update', [$this, 'postUpdateHook']);
 	}
 
 	#[Override]

--- a/xExtension-TTRSS_API/extension.php
+++ b/xExtension-TTRSS_API/extension.php
@@ -5,10 +5,7 @@ final class TTRSS_APIExtension extends Minz_Extension {
 
 	#[Override]
 	public function init(): void {
-		$this->registerHook(
-			'post_update',
-			array($this, 'postUpdateHook')
-		);
+		$this->registerHook('post_update', [self::class, 'postUpdateHook']);
 	}
 
 	#[Override]

--- a/xExtension-TitleWrap/extension.php
+++ b/xExtension-TitleWrap/extension.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-class TitleWrapExtension extends Minz_Extension {
+final class TitleWrapExtension extends Minz_Extension {
+	#[Override]
 	public function init(): void {
 		Minz_View::appendStyle($this->getFileUrl('title_wrap.css', 'css'));
 	}

--- a/xExtension-TitleWrap/extension.php
+++ b/xExtension-TitleWrap/extension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 final class TitleWrapExtension extends Minz_Extension {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		Minz_View::appendStyle($this->getFileUrl('title_wrap.css', 'css'));
 	}

--- a/xExtension-TitleWrap/metadata.json
+++ b/xExtension-TitleWrap/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Title-Wrap",
 	"author": "₣rans de Jonge, Joris Kinable",
 	"description": "Applies a line-wrap to long article titles, as opposed to truncating the title when it overflows its display area.",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"entrypoint": "TitleWrap",
 	"type": "user"
 }

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -7,7 +7,7 @@
  *
  * @author Kevin Papst
  */
-class YouTubeExtension extends Minz_Extension
+final class YouTubeExtension extends Minz_Extension
 {
     /**
      * Video player width
@@ -26,18 +26,11 @@ class YouTubeExtension extends Minz_Extension
      */
 	private bool $useNoCookie = false;
 
-    public function install() {
-        return true;
-    }
-
-    public function uninstall() {
-        return true;
-    }
-
     /**
      * Initialize this extension
      */
-    public function init()
+	#[Override]
+    public function init(): void
     {
         $this->registerHook('entry_before_display', array($this, 'embedYouTubeVideo'));
         $this->registerHook('check_url_before_add', array($this, 'convertYoutubeFeedUrl'));
@@ -250,6 +243,7 @@ class YouTubeExtension extends Minz_Extension
      *  - We save configuration in case of a post.
      *  - We (re)load configuration in all case, so they are in-sync after a save and before a page load.
      */
+	#[Override]
     public function handleConfigureAction(): void
     {
         $this->registerTranslates();

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -29,7 +29,7 @@ final class YouTubeExtension extends Minz_Extension
     /**
      * Initialize this extension
      */
-	#[Override]
+	#[\Override]
     public function init(): void
     {
         $this->registerHook('entry_before_display', [$this, 'embedYouTubeVideo']);
@@ -243,7 +243,7 @@ final class YouTubeExtension extends Minz_Extension
      *  - We save configuration in case of a post.
      *  - We (re)load configuration in all case, so they are in-sync after a save and before a page load.
      */
-	#[Override]
+	#[\Override]
     public function handleConfigureAction(): void
     {
         $this->registerTranslates();

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -32,8 +32,8 @@ final class YouTubeExtension extends Minz_Extension
 	#[Override]
     public function init(): void
     {
-        $this->registerHook('entry_before_display', array($this, 'embedYouTubeVideo'));
-        $this->registerHook('check_url_before_add', array($this, 'convertYoutubeFeedUrl'));
+        $this->registerHook('entry_before_display', [self::class, 'embedYouTubeVideo']);
+        $this->registerHook('check_url_before_add', [self::class, 'convertYoutubeFeedUrl']);
         $this->registerTranslates();
     }
 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -33,11 +33,11 @@ final class YouTubeExtension extends Minz_Extension
     public function init(): void
     {
         $this->registerHook('entry_before_display', [$this, 'embedYouTubeVideo']);
-        $this->registerHook('check_url_before_add', [$this, 'convertYoutubeFeedUrl']);
+        $this->registerHook('check_url_before_add', [self::class, 'convertYoutubeFeedUrl']);
         $this->registerTranslates();
     }
 
-    public function convertYoutubeFeedUrl(string $url): string
+    public static function convertYoutubeFeedUrl(string $url): string
     {
         $matches = [];
 

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -32,8 +32,8 @@ final class YouTubeExtension extends Minz_Extension
 	#[Override]
     public function init(): void
     {
-        $this->registerHook('entry_before_display', [self::class, 'embedYouTubeVideo']);
-        $this->registerHook('check_url_before_add', [self::class, 'convertYoutubeFeedUrl']);
+        $this->registerHook('entry_before_display', [$this, 'embedYouTubeVideo']);
+        $this->registerHook('check_url_before_add', [$this, 'convertYoutubeFeedUrl']);
         $this->registerTranslates();
     }
 

--- a/xExtension-YouTube/metadata.json
+++ b/xExtension-YouTube/metadata.json
@@ -2,7 +2,7 @@
 	"name": "YouTube Video Feed",
 	"author": "Kevin Papst",
 	"description": "Embed YouTube feeds inside article content.",
-	"version": "0.10",
+	"version": "0.11",
 	"entrypoint": "YouTube",
 	"type": "user"
 }

--- a/xExtension-showFeedID/extension.php
+++ b/xExtension-showFeedID/extension.php
@@ -2,7 +2,8 @@
 
 declare(strict_types=1);
 
-class ShowFeedIdExtension extends Minz_Extension {
+final class ShowFeedIdExtension extends Minz_Extension {
+	#[Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('showfeedid.js', 'js'));
 	}

--- a/xExtension-showFeedID/extension.php
+++ b/xExtension-showFeedID/extension.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 final class ShowFeedIdExtension extends Minz_Extension {
-	#[Override]
+	#[\Override]
 	public function init(): void {
 		Minz_View::appendScript($this->getFileUrl('showfeedid.js', 'js'));
 	}

--- a/xExtension-showFeedID/metadata.json
+++ b/xExtension-showFeedID/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ShowFeedID",
 	"author": "math-GH",
 	"description": "Show the feed ID",
-	"version": "0.2",
+	"version": "0.2.1",
 	"entrypoint": "ShowFeedID",
 	"type": "user"
 }


### PR DESCRIPTION
* `composer run-script phpstan-third-party`
* Rename the directory for generate.php to `third-party` instead of `tmp`
* Take advantage of PHPStan checkMissingOverrideMethodAttribute https://phpstan.org/config-reference#checkmissingoverridemethodattribute
* Detected and fixed bug in URL of https://github.com/tunbridgep/freshrss-invidious
