### PR TITLE
[ReadingTime] Add options: Reading speed, Source metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ There are some FreshRSS extensions out there, developed by community members:
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
 
 
+### By [@Lapineige](https://github.com/lapineige)
+
+* [Reading Time](https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime): Add a reading time estimation next to each article.
+
+
 ### By [@Korbak](https://github.com/Korbak)
 
 * [Invidious](https://github.com/Korbak/freshrss-invidious): Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ There are some FreshRSS extensions out there, developed by community members:
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
 
 
-### By [@Lapineige](https://github.com/lapineige)
+### By [@Lapineige](https://github.com/lapineige), [@hkcomori](https://github.com/hkcomori)
 
-* [Reading Time](https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime): Add a reading time estimation next to each article.
+* [Reading Time](https://github.com/FreshRSS/Extensions/tree/master/xExtension-ReadingTime): Add a reading time estimation next to each article.
 
 
 ### By [@Korbak](https://github.com/Korbak)

--- a/README.md
+++ b/README.md
@@ -49,11 +49,6 @@ There are some FreshRSS extensions out there, developed by community members:
 * [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
 
 
-### By [@Lapineige](https://github.com/lapineige)
-
-* [Reading Time](https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime): Add a reading time estimation next to each article.
-
-
 ### By [@Korbak](https://github.com/Korbak)
 
 * [Invidious](https://github.com/Korbak/freshrss-invidious): Displays videos from YouTube feeds inline and replaces every source by the Invidious instance of your choice for an enhanced privacy (no tracking or limitation)

--- a/extensions.json
+++ b/extensions.json
@@ -357,7 +357,7 @@
             "name": "ReadingTime",
             "author": "Lapineige",
             "description": "Add a reading time estimation next to each article",
-            "version": "1.5.1",
+            "version": "1.6.0",
             "entrypoint": "ReadingTime",
             "type": "user",
             "url": "https://github.com/FreshRSS/Extensions",

--- a/extensions.json
+++ b/extensions.json
@@ -344,7 +344,7 @@
         },
         {
             "name": "ReadingTime",
-            "author": "Lapineige",
+            "author": "Lapineige, hkcomori",
             "description": "Add a reading time estimation next to each article",
             "version": "1.6.0",
             "entrypoint": "ReadingTime",

--- a/xExtension-ReadingTime/LICENSE
+++ b/xExtension-ReadingTime/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2016 Lapineige
+Copyright (c) 2016 Lapineige, hkcomori
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -9,7 +9,7 @@ S'installe comme toute les extensions, soit via l'outil intégré dans l'interfa
 Aucune module externe. Une fois activée dans les préférences, l'extension doit fonctionner après avoir recharger la page.
 
 Un indicateur du temps de lecture doit s'afficher dans le nom du flux de chaque article.
-Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. À changer si besoin ici: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26>
+Vous pouvez définir la vitesse de lecture et la méthode de mesure du temps de lecture.
 
 ---
 

--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -1,18 +1,3 @@
-Extension pour FreshRSS (<https://github.com/FreshRSS>)
-
-> **v1.6**
-
-Ajoute une estimation du temps de lecture à côté de chaque article.
-Fonctionne sur les affichages de bureau et mobile.
-
-S'installe comme toute les extensions, soit via l'outil intégré dans l'interface (icône des paramètres -> extensions) soit manuellement en copiant ce dépôt directement dans le dossier `extensions` de votre installation de FreshRSS.
-Aucune module externe. Une fois activée dans les préférences, l'extension doit fonctionner après avoir recharger la page.
-
-Un indicateur du temps de lecture doit s'afficher dans le nom du flux de chaque article.
-Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. À changer si besoin ici: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26>
-
----
-
 Extension for FressRSS (<https://github.com/FreshRSS>)
 
 > **v1.6**

--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -1,3 +1,18 @@
+Extension pour FreshRSS (<https://github.com/FreshRSS>)
+
+> **v1.6**
+
+Ajoute une estimation du temps de lecture à côté de chaque article.
+Fonctionne sur les affichages de bureau et mobile.
+
+S'installe comme toute les extensions, soit via l'outil intégré dans l'interface (icône des paramètres -> extensions) soit manuellement en copiant ce dépôt directement dans le dossier `extensions` de votre installation de FreshRSS.
+Aucune module externe. Une fois activée dans les préférences, l'extension doit fonctionner après avoir recharger la page.
+
+Un indicateur du temps de lecture doit s'afficher dans le nom du flux de chaque article.
+Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. À changer si besoin ici: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26>
+
+---
+
 Extension for FressRSS (<https://github.com/FreshRSS>)
 
 > **v1.6**

--- a/xExtension-ReadingTime/README.md
+++ b/xExtension-ReadingTime/README.md
@@ -1,8 +1,6 @@
 Extension pour FreshRSS (<https://github.com/FreshRSS>)
 
-> **v1.3**
-
-Source: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime>
+> **v1.6**
 
 Ajoute une estimation du temps de lecture à côté de chaque article.
 Fonctionne sur les affichages de bureau et mobile.
@@ -17,9 +15,7 @@ Pour le moment la vitesse de lecture est réglée manuellement à 300 mots/min. 
 
 Extension for FressRSS (<https://github.com/FreshRSS>)
 
-> **v1.3**
-
-Source: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime>
+> **v1.6**
 
 Add a reading time estimation next to each article.
 Works on both desktop and mobile displays.
@@ -27,6 +23,4 @@ Works on both desktop and mobile displays.
 Install it the same way as any other extension, with the integrated tool in the interface (parameters icon -> extensions) or manually by copying this repository directly in the `extensions` folder of your FreshRSS install.
 No external module. Once activated in the preferences, this extension should be working after reloading the page.
 
-A reading time
-For the moment the reading speed is manually set to 300 words/min. If necessary, change it there: <https://framagit.org/Lapineige/FreshRSS_Extension-ReadingTime/blob/master/static/readingtime.js#L26>
-
+You can set reading speed and source metrics to estimate reading time.

--- a/xExtension-ReadingTime/configure.phtml
+++ b/xExtension-ReadingTime/configure.phtml
@@ -2,16 +2,16 @@
 declare(strict_types=1);
 /** @var ReadingTimeExtension $this */
 ?>
-<form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
-	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
+<form action="<?= _url('extension', 'configure', 'e', urlencode($this->getName())) ?>" method="post">
+	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 	<div class="form-group">
-		<label class="group-name" for="reading_time_speed"><?php echo _t('ext.reading_time.speed.label'); ?></label>
+		<label class="group-name" for="reading_time_speed"><?= _t('ext.reading_time.speed.label') ?></label>
 		<div class="group-controls">
 			<input type="number" id="reading_time_speed" name="reading_time_speed" value="<?= $this->getSpeed() ?>" min="1">
 			<p class="help"><?= _i('help') ?> <?= _t('ext.reading_time.speed.help') ?></p>
 		</div>
 
-		<label class="group-name" for="reading_time_speed"><?php echo _t('ext.reading_time.metrics.label'); ?></label>
+		<label class="group-name" for="reading_time_speed"><?= _t('ext.reading_time.metrics.label') ?></label>
 		<div class="group-controls">
 			<select name="reading_time_metrics" id="reading_time_metrics" data-leave-validation="<?= $this->getMetrics() ?>">
 				<option value="words"<?= $this->getMetrics() === 'words' ? ' selected="selected"' : '' ?>><?= _t('ext.reading_time.metrics.words') ?></option>
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 	<div class="form-group form-actions">
 		<div class="group-controls">
-			<button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
-			<button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
+			<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
+			<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
 		</div>
 	</div>
 </form>

--- a/xExtension-ReadingTime/configure.phtml
+++ b/xExtension-ReadingTime/configure.phtml
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+/** @var ReadingTimeExtension $this */
+?>
+<form action="<?php echo _url('extension', 'configure', 'e', urlencode($this->getName())); ?>" method="post">
+	<input type="hidden" name="_csrf" value="<?php echo FreshRSS_Auth::csrfToken(); ?>" />
+	<div class="form-group">
+		<label class="group-name" for="reading_time_speed"><?php echo _t('ext.reading_time.speed.label'); ?></label>
+		<div class="group-controls">
+			<input type="number" id="reading_time_speed" name="reading_time_speed" value="<?= $this->getSpeed() ?>" min="1">
+			<p class="help"><?= _i('help') ?> <?= _t('ext.reading_time.speed.help') ?></p>
+		</div>
+
+		<label class="group-name" for="reading_time_speed"><?php echo _t('ext.reading_time.metrics.label'); ?></label>
+		<div class="group-controls">
+			<select name="reading_time_metrics" id="reading_time_metrics" data-leave-validation="<?= $this->getMetrics() ?>">
+				<option value="words"<?= $this->getMetrics() === 'words' ? ' selected="selected"' : '' ?>><?= _t('ext.reading_time.metrics.words') ?></option>
+				<option value="letters"<?= $this->getMetrics() === 'letters' ? ' selected="selected"' : '' ?>><?= _t('ext.reading_time.metrics.letters') ?></option>
+			</select>
+			<p class="help"><?= _i('help') ?> <?= _t('ext.reading_time.metrics.help') ?></p>
+		</div>
+	</div>
+
+	<div class="form-group form-actions">
+		<div class="group-controls">
+			<button type="submit" class="btn btn-important"><?php echo _t('gen.action.submit'); ?></button>
+			<button type="reset" class="btn"><?php echo _t('gen.action.cancel'); ?></button>
+		</div>
+	</div>
+</form>

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -3,8 +3,81 @@
 declare(strict_types=1);
 
 final class ReadingTimeExtension extends Minz_Extension {
+	private int $speed = 300;
+	private string $metrics = 'words';
+
 	#[\Override]
 	public function init(): void {
+		$this->registerTranslates();
+		if (!FreshRSS_Context::hasUserConf()) {
+			return;
+		}
+		// Defaults
+		$speed = FreshRSS_Context::userConf()->attributeInt('reading_time_speed');
+		if ($speed === null) {
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->speed);
+		} else {
+			$this->speed = $speed;
+		}
+		$metrics = FreshRSS_Context::userConf()->attributeString('reading_time_metrics');
+		if ($metrics === null) {
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->metrics);
+		} else {
+			$this->metrics = $metrics;
+		}
+		if (in_array(null, [$speed, $metrics])) {
+			FreshRSS_Context::userConf()->save();
+		}
+		$this->registerHook('js_vars', [$this, 'getParams']);
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
+	}
+
+	public function getSpeed(): int {
+		return $this->speed;
+	}
+
+	public function getMetrics(): string {
+		return $this->metrics;
+	}
+
+	/**
+	 * @return array{
+	 * 	speed: int,
+	 * 	metrics: string,
+	 * }
+	 */
+	public function getParams(array $vars): array {
+		return array(
+			'reading_time_speed' => $this->speed,
+			'reading_time_metrics' => $this->metrics,
+		);
+	}
+
+	#[\Override]
+	public function handleConfigureAction(): void {
+		$this->registerTranslates();
+
+		if (Minz_Request::isPost()) {
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->validateSpeed(Minz_Request::paramInt('reading_time_speed')));
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->validateMetrics(Minz_Request::paramString('reading_time_metrics')));
+			FreshRSS_Context::userConf()->save();
+		}
+	}
+
+	private function validateSpeed(int $speed): int {
+		if ($speed <= 0) {
+			throw new Minz_ActionException(_t('ext.reading_time.speed.invalid'), Minz_Request::actionName());
+		}
+		return $speed;
+	}
+
+	private function validateMetrics(string $metrics): string {
+		switch ($metrics) {
+			case 'words':
+			case 'letters':
+				return $metrics;
+			default:
+				throw new Minz_ActionException(_t('ext.reading_time.metrics.invalid'), Minz_Request::actionName());
+		}
 	}
 }

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -41,17 +41,18 @@ final class ReadingTimeExtension extends Minz_Extension {
 	}
 
 	/**
-	 * @param array<mixed> $vars
-	 * @return array{
-	 * 	reading_time_speed: int,
-	 * 	reading_time_metrics: string,
-	 * }
+	 * Called from js_vars hook
+	 *
+	 * Pass dynamic parameters to readingtime.js via `window.context.extensions`.
+	 * Chain with other js_vars hooks via $vars.
+	 *
+	 * @param array<mixed> $vars is the result of hooks chained in the previous step.
+	 * @return array<mixed> is passed to the hook chained to the next step.
 	 */
 	public function getParams(array $vars): array {
-		return array(
-			'reading_time_speed' => $this->speed,
-			'reading_time_metrics' => $this->metrics,
-		);
+		$vars['reading_time_speed'] = $this->speed;
+		$vars['reading_time_metrics'] = $this->metrics;
+		return $vars;
 	}
 
 	#[\Override]

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -78,7 +78,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 	/** @throws Minz_ConfigurationParamException */
 	private function validateSpeed(int $speed): int {
 		if ($speed <= 0) {
-			throw new Minz_ConfigurationParamException(_t('ext.reading_time.speed.invalid'));
+			throw new Minz_ConfigurationParamException('Reading speed must be greater than 0');
 		}
 		return $speed;
 	}
@@ -90,7 +90,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 			case 'letters':
 				return $metrics;
 			default:
-				throw new Minz_ConfigurationParamException(_t('ext.reading_time.metrics.invalid'));
+				throw new Minz_ConfigurationParamException('Unsupported source metrics');
 		}
 	}
 }

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -6,6 +6,9 @@ final class ReadingTimeExtension extends Minz_Extension {
 	private int $speed = 300;
 	private string $metrics = 'words';
 
+	/**
+	 * @throws FreshRSS_Context_Exception
+	 */
 	#[\Override]
 	public function init(): void {
 		$this->registerTranslates();
@@ -13,20 +16,20 @@ final class ReadingTimeExtension extends Minz_Extension {
 			return;
 		}
 		// Defaults
-		$speed = FreshRSS_Context::userConf()->attributeInt('reading_time_speed');	// @phpstan-ignore missingType.checkedException
+		$speed = FreshRSS_Context::userConf()->attributeInt('reading_time_speed');
 		if ($speed === null) {
-			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->speed);	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->speed);
 		} else {
 			$this->speed = $speed;
 		}
-		$metrics = FreshRSS_Context::userConf()->attributeString('reading_time_metrics');	// @phpstan-ignore missingType.checkedException
+		$metrics = FreshRSS_Context::userConf()->attributeString('reading_time_metrics');
 		if ($metrics === null) {
-			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->metrics);	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->metrics);
 		} else {
 			$this->metrics = $metrics;
 		}
 		if (in_array(null, [$speed, $metrics], true)) {
-			FreshRSS_Context::userConf()->save();	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->save();
 		}
 		$this->registerHook('js_vars', [$this, 'getParams']);
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
@@ -55,16 +58,20 @@ final class ReadingTimeExtension extends Minz_Extension {
 		return $vars;
 	}
 
+	/**
+	 * @throws FreshRSS_Context_Exception
+	 * @throws Minz_ActionException
+	 */
 	#[\Override]
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 
 		if (Minz_Request::isPost()) {
-			$speed = $this->validateSpeed(Minz_Request::paramInt('reading_time_speed'));	// @phpstan-ignore missingType.checkedException
-			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $speed);	// @phpstan-ignore missingType.checkedException
-			$metrics = $this->validateMetrics(Minz_Request::paramString('reading_time_metrics'));	// @phpstan-ignore missingType.checkedException
-			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $metrics);	// @phpstan-ignore missingType.checkedException
-			FreshRSS_Context::userConf()->save();	// @phpstan-ignore missingType.checkedException
+			$speed = $this->validateSpeed(Minz_Request::paramInt('reading_time_speed'));
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $speed);
+			$metrics = $this->validateMetrics(Minz_Request::paramString('reading_time_metrics'));
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $metrics);
+			FreshRSS_Context::userConf()->save();
 		}
 	}
 

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -25,7 +25,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 		} else {
 			$this->metrics = $metrics;
 		}
-		if (in_array(null, [$speed, $metrics])) {
+		if (in_array(null, [$speed, $metrics], true)) {
 			FreshRSS_Context::userConf()->save();
 		}
 		$this->registerHook('js_vars', [$this, 'getParams']);
@@ -41,9 +41,10 @@ final class ReadingTimeExtension extends Minz_Extension {
 	}
 
 	/**
+	 * @param array<mixed> $vars
 	 * @return array{
-	 * 	speed: int,
-	 * 	metrics: string,
+	 * 	reading_time_speed: int,
+	 * 	reading_time_metrics: string,
 	 * }
 	 */
 	public function getParams(array $vars): array {

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -7,27 +7,26 @@ final class ReadingTimeExtension extends Minz_Extension {
 	private string $metrics = 'words';
 
 	#[\Override]
-	/** @throws FreshRSS_Context_Exception */
 	public function init(): void {
 		$this->registerTranslates();
 		if (!FreshRSS_Context::hasUserConf()) {
 			return;
 		}
 		// Defaults
-		$speed = FreshRSS_Context::userConf()->attributeInt('reading_time_speed');
+		$speed = FreshRSS_Context::userConf()->attributeInt('reading_time_speed');	// @phpstan-ignore missingType.checkedException
 		if ($speed === null) {
-			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->speed);
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->speed);	// @phpstan-ignore missingType.checkedException
 		} else {
 			$this->speed = $speed;
 		}
-		$metrics = FreshRSS_Context::userConf()->attributeString('reading_time_metrics');
+		$metrics = FreshRSS_Context::userConf()->attributeString('reading_time_metrics');	// @phpstan-ignore missingType.checkedException
 		if ($metrics === null) {
-			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->metrics);
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->metrics);	// @phpstan-ignore missingType.checkedException
 		} else {
 			$this->metrics = $metrics;
 		}
 		if (in_array(null, [$speed, $metrics], true)) {
-			FreshRSS_Context::userConf()->save();
+			FreshRSS_Context::userConf()->save();	// @phpstan-ignore missingType.checkedException
 		}
 		$this->registerHook('js_vars', [$this, 'getParams']);
 		Minz_View::appendScript($this->getFileUrl('readingtime.js', 'js'));
@@ -56,17 +55,15 @@ final class ReadingTimeExtension extends Minz_Extension {
 	}
 
 	#[\Override]
-	/**
-	 * @throws FreshRSS_Context_Exception
-	 * @throws Minz_ActionException
-	 */
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 
 		if (Minz_Request::isPost()) {
-			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $this->validateSpeed(Minz_Request::paramInt('reading_time_speed')));
-			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $this->validateMetrics(Minz_Request::paramString('reading_time_metrics')));
-			FreshRSS_Context::userConf()->save();
+			$speed = $this->validateSpeed(Minz_Request::paramInt('reading_time_speed'));	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->_attribute('reading_time_speed', $speed);	// @phpstan-ignore missingType.checkedException
+			$metrics = $this->validateMetrics(Minz_Request::paramString('reading_time_metrics'));	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->_attribute('reading_time_metrics', $metrics);	// @phpstan-ignore missingType.checkedException
+			FreshRSS_Context::userConf()->save();	// @phpstan-ignore missingType.checkedException
 		}
 	}
 

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -7,6 +7,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 	private string $metrics = 'words';
 
 	#[\Override]
+	/** @throws FreshRSS_Context_Exception */
 	public function init(): void {
 		$this->registerTranslates();
 		if (!FreshRSS_Context::hasUserConf()) {
@@ -55,6 +56,10 @@ final class ReadingTimeExtension extends Minz_Extension {
 	}
 
 	#[\Override]
+	/**
+	 * @throws FreshRSS_Context_Exception
+	 * @throws Minz_ActionException
+	 */
 	public function handleConfigureAction(): void {
 		$this->registerTranslates();
 
@@ -65,6 +70,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 		}
 	}
 
+	/** @throws Minz_ActionException */
 	private function validateSpeed(int $speed): int {
 		if ($speed <= 0) {
 			throw new Minz_ActionException(_t('ext.reading_time.speed.invalid'), Minz_Request::actionName());
@@ -72,6 +78,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 		return $speed;
 	}
 
+	/** @throws Minz_ActionException */
 	private function validateMetrics(string $metrics): string {
 		switch ($metrics) {
 			case 'words':

--- a/xExtension-ReadingTime/extension.php
+++ b/xExtension-ReadingTime/extension.php
@@ -60,7 +60,7 @@ final class ReadingTimeExtension extends Minz_Extension {
 
 	/**
 	 * @throws FreshRSS_Context_Exception
-	 * @throws Minz_ActionException
+	 * @throws Minz_ConfigurationParamException
 	 */
 	#[\Override]
 	public function handleConfigureAction(): void {
@@ -75,22 +75,22 @@ final class ReadingTimeExtension extends Minz_Extension {
 		}
 	}
 
-	/** @throws Minz_ActionException */
+	/** @throws Minz_ConfigurationParamException */
 	private function validateSpeed(int $speed): int {
 		if ($speed <= 0) {
-			throw new Minz_ActionException(_t('ext.reading_time.speed.invalid'), Minz_Request::actionName());
+			throw new Minz_ConfigurationParamException(_t('ext.reading_time.speed.invalid'));
 		}
 		return $speed;
 	}
 
-	/** @throws Minz_ActionException */
+	/** @throws Minz_ConfigurationParamException */
 	private function validateMetrics(string $metrics): string {
 		switch ($metrics) {
 			case 'words':
 			case 'letters':
 				return $metrics;
 			default:
-				throw new Minz_ActionException(_t('ext.reading_time.metrics.invalid'), Minz_Request::actionName());
+				throw new Minz_ConfigurationParamException(_t('ext.reading_time.metrics.invalid'));
 		}
 	}
 }

--- a/xExtension-ReadingTime/i18n/en/ext.php
+++ b/xExtension-ReadingTime/i18n/en/ext.php
@@ -1,0 +1,18 @@
+<?php
+
+return array(
+	'reading_time' => array(
+		'speed' => array(
+			'label' => 'Reading speed',
+			'help' => 'Conversion factor to reading time from metrics',
+			'invalid' => 'Reading speed must be greater than 0',
+		),
+		'source' => array(
+			'label' => 'Source metrics',
+			'help' => 'Source of reading time calculation',
+			'words' => 'Number of words',
+			'letters' => 'Number of letters',
+			'invalid' => 'Unsupported source metrics',
+		),
+	),
+);

--- a/xExtension-ReadingTime/i18n/en/ext.php
+++ b/xExtension-ReadingTime/i18n/en/ext.php
@@ -5,14 +5,12 @@ return array(
 		'speed' => array(
 			'label' => 'Reading speed',
 			'help' => 'Conversion factor to reading time from metrics',
-			'invalid' => 'Reading speed must be greater than 0',
 		),
 		'metrics' => array(
 			'label' => 'Source metrics',
 			'help' => 'Source of reading time calculation',
 			'words' => 'Number of words',
 			'letters' => 'Number of letters',
-			'invalid' => 'Unsupported source metrics',
 		),
 	),
 );

--- a/xExtension-ReadingTime/i18n/en/ext.php
+++ b/xExtension-ReadingTime/i18n/en/ext.php
@@ -7,7 +7,7 @@ return array(
 			'help' => 'Conversion factor to reading time from metrics',
 			'invalid' => 'Reading speed must be greater than 0',
 		),
-		'source' => array(
+		'metrics' => array(
 			'label' => 'Source metrics',
 			'help' => 'Source of reading time calculation',
 			'words' => 'Number of words',

--- a/xExtension-ReadingTime/i18n/fr/ext.php
+++ b/xExtension-ReadingTime/i18n/fr/ext.php
@@ -5,14 +5,12 @@ return array(
 		'speed' => array(
 			'label' => 'Vitesse de lecture',
 			'help' => 'Paramètre de calcul, dépendant de la méthode',
-			'invalid' => 'La vitesse de lecture doit être supérieure à 0',
 		),
 		'metrics' => array(
 			'label' => 'Méthodes',
 			'help' => 'Méthode de calcul du temps de lecture',
 			'words' => 'Nombre de mots',
 			'letters' => 'Nombre de lettres',
-			'invalid' => 'Méthode non prise en charge',
 		),
 	),
 );

--- a/xExtension-ReadingTime/i18n/fr/ext.php
+++ b/xExtension-ReadingTime/i18n/fr/ext.php
@@ -1,0 +1,18 @@
+<?php
+
+return array(
+	'reading_time' => array(
+		'speed' => array(
+			'label' => 'Vitesse de lecture',
+			'help' => 'Paramètre de calcul, dépendant de la méthode',
+			'invalid' => 'La vitesse de lecture doit être supérieure à 0',
+		),
+		'metrics' => array(
+			'label' => 'Méthodes',
+			'help' => 'Méthode de calcul du temps de lecture',
+			'words' => 'Nombre de mots',
+			'letters' => 'Nombre de lettres',
+			'invalid' => 'Méthode non prise en charge',
+		),
+	),
+);

--- a/xExtension-ReadingTime/i18n/ja/ext.php
+++ b/xExtension-ReadingTime/i18n/ja/ext.php
@@ -1,0 +1,18 @@
+<?php
+
+return array(
+	'reading_time' => array(
+		'speed' => array(
+			'label' => '読書速度',
+			'help' => '基準値を読書時間に変換する係数',
+			'invalid' => '読書速度は0より大きい値でなければなりません',
+		),
+		'metrics' => array(
+			'label' => '基準値',
+			'help' => '読書時間を推定する基準値',
+			'words' => '単語数',
+			'letters' => '文字数',
+			'invalid' => 'サポートされていない基準値です',
+		),
+	),
+);

--- a/xExtension-ReadingTime/i18n/ja/ext.php
+++ b/xExtension-ReadingTime/i18n/ja/ext.php
@@ -5,14 +5,12 @@ return array(
 		'speed' => array(
 			'label' => '読書速度',
 			'help' => '基準値を読書時間に変換する係数',
-			'invalid' => '読書速度は0より大きい値でなければなりません',
 		),
 		'metrics' => array(
 			'label' => '基準値',
 			'help' => '読書時間を推定する基準値',
 			'words' => '単語数',
 			'letters' => '文字数',
-			'invalid' => 'サポートされていない基準値です',
 		),
 	),
 );

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ReadingTime",
 	"author": "Lapineige",
 	"description": "Add a reading time estimation next to each article",
-	"version": "1.5.1",
+	"version": "1.5.2",
 	"entrypoint": "ReadingTime",
 	"type": "user"
 }

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -1,6 +1,6 @@
 {
 	"name": "ReadingTime",
-	"author": "Lapineige",
+	"author": "Lapineige, hkcomori",
 	"description": "Add a reading time estimation next to each article",
 	"version": "1.6.0",
 	"entrypoint": "ReadingTime",

--- a/xExtension-ReadingTime/metadata.json
+++ b/xExtension-ReadingTime/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ReadingTime",
 	"author": "Lapineige",
 	"description": "Add a reading time estimation next to each article",
-	"version": "1.5.2",
+	"version": "1.6.0",
 	"entrypoint": "ReadingTime",
 	"type": "user"
 }

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -97,36 +97,4 @@
 	} else {
 		document.addEventListener('freshrss:globalContextLoaded', add_load_more_listener, false);
 	}
-
-	const event = new Event('freshrss:globalContextLoaded');
-
-	function startDetectGlobalContextLoaded() {
-		const globalContextElement = document.getElementById('jsonVars');
-
-		if (globalContextElement !== null) {
-			// Wait until load global context
-			const observer = new MutationObserver((e) => {
-				if (e[0].removedNodes[0].id != 'jsonVars') {
-					return;
-				}
-				observer.disconnect();
-				document.dispatchEvent(event);
-			});
-
-			observer.observe(globalContextElement.parentElement, {
-				attributes: true,
-				childList: true,
-				subtree: true,
-			});
-		} else {
-			// Already loaded global context
-			document.dispatchEvent(event);
-		}
-	}
-
-	if (document.readyState && document.readyState !== 'loading') {
-		startDetectGlobalContextLoaded();
-	} else {
-		document.addEventListener('DOMContentLoaded', startDetectGlobalContextLoaded, false);
-	}
 }());

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -81,11 +81,47 @@
 		document.body.addEventListener('freshrss:load-more', function (e) {
 			reading_time.init();
 		});
+
+		if (window.console) {
+			console.log('ReadingTime init done.');
+		}
+	}
+
+	if (document.readyState && document.readyState !== 'loading' && typeof window.context !== 'undefined' && typeof window.context.extensions !== 'undefined') {
+		add_load_more_listener();
+	} else {
+		document.addEventListener('freshrss:globalContextLoaded', add_load_more_listener, false);
+	}
+
+	const event = new Event('freshrss:globalContextLoaded');
+
+	function startDetectGlobalContextLoaded() {
+		const globalContextElement = document.getElementById('jsonVars');
+
+		if (globalContextElement !== null) {
+			// Wait until load global context
+			const observer = new MutationObserver((e) => {
+				if (e[0].removedNodes[0].id != 'jsonVars') {
+					return;
+				}
+				observer.disconnect();
+				document.dispatchEvent(event);
+			});
+
+			observer.observe(globalContextElement.parentElement, {
+				attributes: true,
+				childList: true,
+				subtree: true,
+			});
+		} else {
+			// Already loaded global context
+			document.dispatchEvent(event);
+		}
 	}
 
 	if (document.readyState && document.readyState !== 'loading') {
-		add_load_more_listener();
-	} else if (document.addEventListener) {
-		document.addEventListener('DOMContentLoaded', add_load_more_listener, false);
+		startDetectGlobalContextLoaded();
+	} else {
+		document.addEventListener('DOMContentLoaded', startDetectGlobalContextLoaded, false);
 	}
 }());

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -1,4 +1,4 @@
-(function reading_time() {
+document.addEventListener('DOMContentLoaded', function reading_time() {
 	'use strict';
 
 	const reading_time = {
@@ -88,4 +88,4 @@
 	} else if (document.addEventListener) {
 		document.addEventListener('DOMContentLoaded', add_load_more_listener, false);
 	}
-}());
+});

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -13,6 +13,7 @@
 			const flux_list = document.querySelectorAll('[id^="flux_"]');
 			const speed = window.context.extensions.reading_time_speed;
 			const metrics = window.context.extensions.reading_time_metrics;
+			const language = window.context.i18n.language;
 
 			for (let i = 0; i < flux_list.length; i++) {
 				if ('readingTime' in flux_list[i].dataset) {
@@ -22,9 +23,9 @@
 				reading_time.flux = flux_list[i];
 
 				if (metrics == 'letters') {
-					reading_time.count = reading_time.flux_letters_count(flux_list[i]);
+					reading_time.count = reading_time.flux_letters_count(flux_list[i], language);
 				} else {  // words
-					reading_time.count = reading_time.flux_words_count(flux_list[i]);
+					reading_time.count = reading_time.flux_words_count(flux_list[i], language);
 				}
 				reading_time.reading_time = reading_time.calc_read_time(reading_time.count, speed);
 
@@ -43,7 +44,9 @@
 			}
 		},
 
-		flux_words_count: function flux_words_count(flux) {
+		flux_words_count: function flux_words_count(flux, language) {
+			const segmenter = new Intl.Segmenter(language, { granularity: 'grapheme' });
+
 			// get innerText, from the article itself (not the header, not the bottom line):
 			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
 
@@ -52,17 +55,19 @@
 			reading_time.innerText = reading_time.innerText.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
 			reading_time.innerText = reading_time.innerText.replace(/\n /, '\n'); // exclude newline with a start spacing
 
-			return reading_time.innerText.split(' ').length;
+			return [...segmenter.segment(reading_time.innerText.split(' '))].length;
 		},
 
-		flux_letters_count: function flux_letters_count(flux) {
+		flux_letters_count: function flux_letters_count(flux, language) {
+			const segmenter = new Intl.Segmenter(language, { granularity: 'grapheme' });
+
 			// get innerText, from the article itself (not the header, not the bottom line):
 			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
 
 			// clean the text by removing excessive whitespace
 			reading_time.innerText = reading_time.innerText.replace(/\s/gi, ''); // exclude white-space
 
-			return reading_time.innerText.length;
+			return [...segmenter.segment(reading_time.innerText)].length;
 		},
 
 		calc_read_time: function calc_read_time(count, speed) {

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -4,7 +4,7 @@
 	const reading_time = {
 		flux_list: null,
 		flux: null,
-		textContent: null,
+		innerText: null,
 		count: null,
 		read_time: null,
 		reading_time: null,
@@ -44,25 +44,25 @@
 		},
 
 		flux_words_count: function flux_words_count(flux) {
-			// get textContent, from the article itself (not the header, not the bottom line):
-			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
+			// get innerText, from the article itself (not the header, not the bottom line):
+			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
 
 			// split the text to count the words correctly (source: http://www.mediacollege.com/internet/javascript/text/count-words.html)
-			reading_time.textContent = reading_time.textContent.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
-			reading_time.textContent = reading_time.textContent.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
-			reading_time.textContent = reading_time.textContent.replace(/\n /, '\n'); // exclude newline with a start spacing
+			reading_time.innerText = reading_time.innerText.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
+			reading_time.innerText = reading_time.innerText.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
+			reading_time.innerText = reading_time.innerText.replace(/\n /, '\n'); // exclude newline with a start spacing
 
-			return reading_time.textContent.split(' ').length;
+			return reading_time.innerText.split(' ').length;
 		},
 
 		flux_letters_count: function flux_letters_count(flux) {
-			// get textContent, from the article itself (not the header, not the bottom line):
-			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
+			// get innerText, from the article itself (not the header, not the bottom line):
+			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
 
 			// clean the text by removing excessive whitespace
-			reading_time.textContent = reading_time.textContent.replace(/\s/gi, ''); // exclude white-space
+			reading_time.innerText = reading_time.innerText.replace(/\s/gi, ''); // exclude white-space
 
-			return reading_time.textContent.length;
+			return reading_time.innerText.length;
 		},
 
 		calc_read_time: function calc_read_time(count, speed) {

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -4,7 +4,7 @@
 	const reading_time = {
 		flux_list: null,
 		flux: null,
-		innerText: null,
+		textContent: null,
 		count: null,
 		read_time: null,
 		reading_time: null,
@@ -47,27 +47,27 @@
 		flux_words_count: function flux_words_count(flux, language) {
 			const segmenter = new Intl.Segmenter(language, { granularity: 'grapheme' });
 
-			// get innerText, from the article itself (not the header, not the bottom line):
-			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
+			// get textContent, from the article itself (not the header, not the bottom line):
+			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
 
 			// split the text to count the words correctly (source: http://www.mediacollege.com/internet/javascript/text/count-words.html)
-			reading_time.innerText = reading_time.innerText.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
-			reading_time.innerText = reading_time.innerText.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
-			reading_time.innerText = reading_time.innerText.replace(/\n /, '\n'); // exclude newline with a start spacing
+			reading_time.textContent = reading_time.textContent.replace(/(^\s*)|(\s*$)/gi, ''); // exclude  start and end white-space
+			reading_time.textContent = reading_time.textContent.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
+			reading_time.textContent = reading_time.textContent.replace(/\n /, '\n'); // exclude newline with a start spacing
 
-			return [...segmenter.segment(reading_time.innerText.split(' '))].length;
+			return [...segmenter.segment(reading_time.textContent.split(' '))].length;
 		},
 
 		flux_letters_count: function flux_letters_count(flux, language) {
 			const segmenter = new Intl.Segmenter(language, { granularity: 'grapheme' });
 
-			// get innerText, from the article itself (not the header, not the bottom line):
-			reading_time.innerText = flux.querySelector('.flux_content .content').innerText;
+			// get textContent, from the article itself (not the header, not the bottom line):
+			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
 
 			// clean the text by removing excessive whitespace
-			reading_time.innerText = reading_time.innerText.replace(/\s/gi, ''); // exclude white-space
+			reading_time.textContent = reading_time.textContent.replace(/\s/gi, ''); // exclude white-space
 
-			return [...segmenter.segment(reading_time.innerText)].length;
+			return [...segmenter.segment(reading_time.textContent)].length;
 		},
 
 		calc_read_time: function calc_read_time(count, speed) {

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -5,12 +5,14 @@
 		flux_list: null,
 		flux: null,
 		textContent: null,
-		words_count: null,
+		count: null,
 		read_time: null,
 		reading_time: null,
 
 		init: function () {
 			const flux_list = document.querySelectorAll('[id^="flux_"]');
+			const speed = window.context.extensions.reading_time_speed;
+			const metrics = window.context.extensions.reading_time_metrics;
 
 			for (let i = 0; i < flux_list.length; i++) {
 				if ('readingTime' in flux_list[i].dataset) {
@@ -19,9 +21,12 @@
 
 				reading_time.flux = flux_list[i];
 
-				reading_time.words_count = reading_time.flux_words_count(flux_list[i]); // count the words
-				// change this number (in words) to your preferred reading speed:
-				reading_time.reading_time = reading_time.calc_read_time(reading_time.words_count, 300);
+				if (metrics == 'letters') {
+					reading_time.count = reading_time.flux_letters_count(flux_list[i]);
+				} else {  // words
+					reading_time.count = reading_time.flux_words_count(flux_list[i]);
+				}
+				reading_time.reading_time = reading_time.calc_read_time(reading_time.count, speed);
 
 				flux_list[i].dataset.readingTime = reading_time.reading_time;
 
@@ -50,8 +55,18 @@
 			return reading_time.textContent.split(' ').length;
 		},
 
-		calc_read_time: function calc_read_time(wd_count, speed) {
-			reading_time.read_time = Math.round(wd_count / speed);
+		flux_letters_count: function flux_letters_count(flux) {
+			// get textContent, from the article itself (not the header, not the bottom line):
+			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
+
+			// clean the text by removing excessive whitespace
+			reading_time.textContent = reading_time.textContent.replace(/\s/gi, ''); // exclude white-space
+
+			return reading_time.textContent.length;
+		},
+
+		calc_read_time: function calc_read_time(count, speed) {
+			reading_time.read_time = Math.round(count / speed);
 
 			if (reading_time.read_time === 0) {
 				reading_time.read_time = '<1';

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -1,4 +1,4 @@
-document.addEventListener('DOMContentLoaded', function reading_time() {
+(function reading_time() {
 	'use strict';
 
 	const reading_time = {
@@ -88,4 +88,4 @@ document.addEventListener('DOMContentLoaded', function reading_time() {
 	} else if (document.addEventListener) {
 		document.addEventListener('DOMContentLoaded', add_load_more_listener, false);
 	}
-});
+}());

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -25,7 +25,7 @@
 				if (metrics == 'letters') {
 					reading_time.count = reading_time.flux_letters_count(flux_list[i], language);
 				} else {  // words
-					reading_time.count = reading_time.flux_words_count(flux_list[i], language);
+					reading_time.count = reading_time.flux_words_count(flux_list[i]);
 				}
 				reading_time.reading_time = reading_time.calc_read_time(reading_time.count, speed);
 
@@ -44,9 +44,7 @@
 			}
 		},
 
-		flux_words_count: function flux_words_count(flux, language) {
-			const segmenter = new Intl.Segmenter(language, { granularity: 'grapheme' });
-
+		flux_words_count: function flux_words_count(flux) {
 			// get textContent, from the article itself (not the header, not the bottom line):
 			reading_time.textContent = flux.querySelector('.flux_content .content').textContent;
 
@@ -55,7 +53,7 @@
 			reading_time.textContent = reading_time.textContent.replace(/[ ]{2,}/gi, ' '); // 2 or more space to 1
 			reading_time.textContent = reading_time.textContent.replace(/\n /, '\n'); // exclude newline with a start spacing
 
-			return [...segmenter.segment(reading_time.textContent.split(' '))].length;
+			return reading_time.textContent.split(' ').length;
 		},
 
 		flux_letters_count: function flux_letters_count(flux, language) {

--- a/xExtension-ReadingTime/static/readingtime.js
+++ b/xExtension-ReadingTime/static/readingtime.js
@@ -92,7 +92,7 @@
 		}
 	}
 
-	if (document.readyState && document.readyState !== 'loading' && typeof window.context !== 'undefined' && typeof window.context.extensions !== 'undefined') {
+	if (typeof window.context !== 'undefined' && typeof window.context.extensions !== 'undefined') {
 		add_load_more_listener();
 	} else {
 		document.addEventListener('freshrss:globalContextLoaded', add_load_more_listener, false);


### PR DESCRIPTION
fix #292

https://github.com/FreshRSS/Extensions/issues/292#issuecomment-2674187249 suggested a policy of using letters for all languages, but my research shows that reading speed in English is usually measured by word count. So I have provided a choice in the metrics. That is, the original policy of #292.

I'm using the `js_vars` hook for the first time, is the usage correct?
It works fine now, but the `js_vars` hook is a `OneToOne` hook, so it might conflict if we use it in another extension too.