### PR TITLE
Prevent overwrite of js_vars, and try to avoid name conflicts

### DIFF
--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -15,13 +15,14 @@ final class QuickCollapseExtension extends Minz_Extension {
 	/**
 	 * @return array<string, string|array<string, string>>
 	 */
-	public function jsVars(): array {
-		return [
+	public function jsVars(array $vars): array {
+		$vars['quick_collapse'] = [
 			'icon_url_in' => $this->getFileUrl('in.svg'),
 			'icon_url_out' => $this->getFileUrl('out.svg'),
 			'i18n' => [
 				'toggle_collapse' => _t('gen.js.toggle_collapse'),
-			],
+			]
 		];
+		return $vars;
 	}
 }

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -13,7 +13,8 @@ final class QuickCollapseExtension extends Minz_Extension {
 	}
 
 	/**
-	 * @return array<string, string|array<string, string>>
+	 * @param array<mixed> $vars
+	 * @return array<mixed>
 	 */
 	public function jsVars(array $vars): array {
 		$vars['quick_collapse'] = [

--- a/xExtension-QuickCollapse/extension.php
+++ b/xExtension-QuickCollapse/extension.php
@@ -13,8 +13,8 @@ final class QuickCollapseExtension extends Minz_Extension {
 	}
 
 	/**
-	 * @param array<mixed> $vars
-	 * @return array<mixed>
+	 * @param array<string,mixed> $vars
+	 * @return array<string,mixed>
 	 */
 	public function jsVars(array $vars): array {
 		$vars['quick_collapse'] = [

--- a/xExtension-QuickCollapse/metadata.json
+++ b/xExtension-QuickCollapse/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Quick Collapse",
 	"author": "romibi and Marien Fressinaud",
 	"description": "Quickly change from folded to unfolded articles",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"entrypoint": "QuickCollapse",
 	"type": "user"
 }

--- a/xExtension-QuickCollapse/static/script.js
+++ b/xExtension-QuickCollapse/static/script.js
@@ -32,9 +32,9 @@
 		}
 
 		const toggleElem = document.getElementById('toggle-collapse');
-		toggleElem.title = context.extensions.i18n.toggle_collapse;
-		toggleElem.innerHTML = `<img class="icon uncollapse" src="${context.extensions.icon_url_out}" alt="↕" />`;
-		toggleElem.innerHTML += `<img class="icon collapse" src="${context.extensions.icon_url_in}" alt="✖" />`;
+		toggleElem.title = context.extensions.quick_collapse.i18n.toggle_collapse;
+		toggleElem.innerHTML = `<img class="icon uncollapse" src="${context.extensions.quick_collapse.icon_url_out}" alt="↕" />`;
+		toggleElem.innerHTML += `<img class="icon collapse" src="${context.extensions.quick_collapse.icon_url_in}" alt="✖" />`;
 
 		if (context.hide_posts) {
 			toggleElem.classList.add('collapsed');


### PR DESCRIPTION
Stops QuickCollapse from breaking other extensions