### PR TITLE
ShowFeedID improvements v2

### DIFF
--- a/xExtension-showFeedID/extension.php
+++ b/xExtension-showFeedID/extension.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 final class ShowFeedIdExtension extends Minz_Extension {
 	#[\Override]
 	public function init(): void {
-		if (Minz_Request::paramString('c') === 'subscription') {
+		if (Minz_Request::paramString('c') === 'subscription'
+			&& Minz_Request::actionName() === 'index') {
 			$this->registerTranslates();
 			$this->registerHook('js_vars', [$this, 'jsVars']);
 			Minz_View::appendScript($this->getFileUrl('showfeedid.js'));

--- a/xExtension-showFeedID/metadata.json
+++ b/xExtension-showFeedID/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ShowFeedID",
 	"author": "math-GH, Inverle",
 	"description": "Show the ID of feed and category",
-	"version": "0.4.0",
+	"version": "0.4.1",
 	"entrypoint": "ShowFeedID",
 	"type": "user"
 }

--- a/xExtension-showFeedID/static/showfeedid.js
+++ b/xExtension-showFeedID/static/showfeedid.js
@@ -5,16 +5,25 @@ window.addEventListener("load", function () {
 	const i18n = context.extensions.showfeedid_i18n;
 
 	const div = document.querySelector('h1 ~ div');
-	const button = document.createElement('button');
+	const button = document.createElement('a');
 
 	button.classList.add('btn');
+	button.classList.add('btn-icon-text');
 	button.id = 'showFeedId';
 	button.innerHTML = '<img class="icon" src="../themes/icons/look.svg" /> <span>' + i18n.show + '</span>';
-	if (new URLSearchParams(location.search).get('error')) {
-		button.style.display = 'block';
-		button.style.marginTop = '1rem';
-	}
+
 	div.appendChild(button);
+
+	const parent = button.parentElement;
+	parent.style.display = 'inline-flex';
+	parent.style.flexWrap = 'wrap';
+	parent.style.gap = '0.5rem';
+
+	// Check if only feeds with errors are being shown
+	if (document.querySelector('main.post > p.alert.alert-warn')) {
+		parent.style.flexDirection = 'column';
+		button.style.marginTop = '0.5rem';
+	}
 
 	const buttonText = button.querySelector('span');
 


### PR DESCRIPTION
- Only show the button on the correct pages, instead of also incorrectly showing it on the `/i/?c=subscription&a=feed` page
- More consistent styling for the button