### PR TITLE
Bugfix for ShowFeedID button

### DIFF
--- a/xExtension-showFeedID/metadata.json
+++ b/xExtension-showFeedID/metadata.json
@@ -2,7 +2,7 @@
 	"name": "ShowFeedID",
 	"author": "math-GH, Inverle",
 	"description": "Show the ID of feed and category",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"entrypoint": "ShowFeedID",
 	"type": "user"
 }

--- a/xExtension-showFeedID/static/showfeedid.js
+++ b/xExtension-showFeedID/static/showfeedid.js
@@ -4,7 +4,12 @@ window.addEventListener("load", function () {
 	// eslint-disable-next-line no-undef
 	const i18n = context.extensions.showfeedid_i18n;
 
-	const div = document.querySelector('h1 ~ div');
+	let div = document.querySelector('h1 ~ div');
+	if (div.classList.contains('drop-section')) {
+		div = document.createElement('div');
+		document.querySelector('h1').after(div);
+	}
+
 	const button = document.createElement('a');
 
 	button.classList.add('btn');


### PR DESCRIPTION
When there aren't any feeds with errors, the button for showing feeds with only errors is gone, along with its `<div>` container.

This caused the following bug to happen:

![image](https://github.com/user-attachments/assets/c13cd2be-df4d-49bd-b015-ac2679ac34cd)

After the bugfix:

![image](https://github.com/user-attachments/assets/218921d5-569a-471f-b146-4c3d58faae4f)
