### PR TITLE
Automatic feed channel icons feature for xExtension-YouTube

### DIFF
--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -24,6 +24,13 @@ declare(strict_types=1);
 		</div>
 
 		<div class="group-controls">
+			<label class="checkbox" for="yt_download_channel_icons">
+				<input type="checkbox" id="yt_download_channel_icons" name="yt_download_channel_icons" value="1" <?php echo $this->isDownloadIcons() ? 'checked' : ''; ?>>
+				<?php echo _t('ext.yt_videos.download_channel_icons'); ?>
+			</label>
+		</div>
+
+		<div class="group-controls">
 			<label class="checkbox" for="yt_nocookie">
 				<input type="checkbox" id="yt_nocookie" name="yt_nocookie" value="1" <?php echo $this->isUseNoCookieDomain() ? 'checked' : ''; ?>>
 				<?php echo _t('ext.yt_videos.use_nocookie'); ?>
@@ -38,8 +45,3 @@ declare(strict_types=1);
 		</div>
 	</div>
 </form>
-
-<p>
-	<?php echo _t('ext.yt_videos.updates'); ?>
-	<a href="https://github.com/kevinpapst/freshrss-youtube" target="_blank">GitHub</a>.
-</p>

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -4,8 +4,8 @@ return array(
 	'yt_videos' => array(
 		'height' => 'Höhe des Players',
 		'width' => 'Breite des Players',
-		'updates' => 'Die neueste Version des Plugins findest Du bei',
 		'show_content' => 'Zeige den Inhalt des Feeds an',
+		'download_channel_icons' => 'Automatically download and set channel icons for feeds',
 		'use_nocookie' => 'Verwende die Cookie-freie Domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -4,8 +4,8 @@ return array(
 	'yt_videos' => array(
 		'height' => 'Player height',
 		'width' => 'Player width',
-		'updates' => 'You can find the latest extension version at',
 		'show_content' => 'Display the feeds content',
+		'download_channel_icons' => 'Automatically download and set channel icons for feeds',
 		'use_nocookie' => 'Use the cookie-free domain www.youtube-nocookie.com',
 	),
 );

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -4,8 +4,8 @@ return array(
 	'yt_videos' => array(
 		'height' => 'Hauteur du lecteur',
 		'width' => 'Largeur du lecteur',
-		'updates' => 'Vous pouvez trouver la dernière mise à jour de l’extension sur ',
 		'show_content' => 'Afficher le contenu du flux',
+		'download_channel_icons' => 'Automatically download and set channel icons for feeds',
 		'use_nocookie' => 'Utiliser le domaine www.youtube-nocookie.com pour éviter les cookies',
 	),
 );

--- a/xExtension-YouTube/i18n/tr/ext.php
+++ b/xExtension-YouTube/i18n/tr/ext.php
@@ -4,8 +4,8 @@ return array(
 	'yt_videos' => array(
 		'height' => 'Oynatıcı yükseklik',
 		'width' => 'Oynatıcı genişlik',
-		'updates' => 'En son uzantı sürümünü şu adreste bulabilirsiniz:',
 		'show_content' => 'Yayın içeriğini görüntüle',
+		'download_channel_icons' => 'Automatically download and set channel icons for feeds',
 		'use_nocookie' => 'Çerezsiz olan "www.youtube-nocookie.com" alan adını kullanın',
 	),
 );


### PR DESCRIPTION
Dependent on https://github.com/FreshRSS/FreshRSS/pull/7646

Right now, the icon only gets set after the feed is added.

TODO:
- [ ] redownload icon whenever needed
- [ ] add option to download icons for all of the channel feeds
- [ ] add option to reset all of the channel icons back to the YT icon