### PR TITLE
Prevent HTML injection by sanitizing extension values

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -534,7 +534,6 @@
             "version": "0.3.1",
             "description": "Translate article titles of the specified feed into Chinese.",
             "author": "jacob2826",
-            "website": "https://github.com/jacob2826/FreshRSS-TranslateTitlesCN",
             "entrypoint": "TranslateTitles",
             "type": "user",
             "url": "https://github.com/jacob2826/FreshRSS-TranslateTitlesCN",

--- a/generate.php
+++ b/generate.php
@@ -57,6 +57,33 @@ foreach ($gitRepositories as $key => $gitRepository) {
 			$metadata['version'] = is_scalar($metadata['version'] ?? null) ? strval($metadata['version']) : '';
 			$metadata['method'] = TYPE_GIT;
 			$metadata['directory'] = ($directory === sha1($gitRepository)) ? '.' : $directory;
+
+			$required_keys = [
+				'name',
+				'author',
+				'description',
+				'version',
+				'entrypoint',
+				'type',
+				'url',
+				'method',
+				'directory',
+			];
+
+			// Sanitize extension values to prevent HTML injection (when rendered by FreshRSS)
+			// Also clean unnecessary keys
+			foreach ($metadata as $k => $v) {
+				if ($k === 'description') {
+					continue;
+				}
+				if (!in_array($k, $required_keys, true)) {
+					unset($metadata[$k]);
+					continue;
+				}
+				$metadata[$k] = htmlspecialchars(is_string($metadata[$k]) ? $metadata[$k] : '', ENT_COMPAT, 'UTF-8');
+			}
+			$metadata['description'] = strip_tags(is_string($metadata['description']) ? $metadata['description'] : '', allowed_tags: ['a']);
+
 			$extensions[] = $metadata;
 		} catch (Exception $exception) {
 			continue;


### PR DESCRIPTION
Currently any third-party extension repository can edit their `metadata.json` to insert something like `<meta http-equiv=refresh content=0;url=//google.com>` to redirect the Extensions page of every FreshRSS instance to `google.com`.

This fix won't require users to update FreshRSS.