### PR TITLE
Add ShareToLinkwarden extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@pe1uca](https://github.com/pe1uca)  
 
 * [Rate limiter](https://github.com/pe1uca/xExtension-RateLimiter/): Prevents FreshRSS from making too many requests to the same site in a defined amount of time.  
+
+### By [@daften](https://github.com/daften)  
+
+* [Share To Linkwarden](https://github.com/daften/xExtension-ShareToLinkwarden/): Allows sharing items directly to a self-hosted Linkwarden instance.

--- a/extensions.json
+++ b/extensions.json
@@ -431,6 +431,17 @@
             "directory": "xExtension-ShareByEmail"
         },
         {
+            "name": "Share To Linkwarden",
+            "author": "Dieter Blomme",
+            "description": "Share to a self-hosted Linkwarden instance directly.",
+            "version": "0.1.1",
+            "entrypoint": "ShareToLinkwarden",
+            "type": "user",
+            "url": "https://github.com/daften/xExtension-ShareToLinkwarden",
+            "method": "git",
+            "directory": "."
+        },
+        {
             "name": "ShowFeedID",
             "author": "math-GH, Inverle",
             "description": "Show the ID of feed and category",

--- a/repositories.json
+++ b/repositories.json
@@ -100,4 +100,7 @@
 }, {
 	"url": "https://github.com/pe1uca/xExtension-RateLimiter",
 	"type": "git"
+}, {
+	"url": "https://github.com/daften/xExtension-ShareToLinkwarden",
+	"type": "git"
 }]


### PR DESCRIPTION
The extension allows sharing directly to Linkwarden via the API.

fix https://github.com/FreshRSS/FreshRSS/issues/6203