### PR TITLE
Add the new paywall extention description

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,10 @@ There are some FreshRSS extensions out there, developed by community members:
 
 ### By [@aledeg](https://github.com/aledeg)
 
-* [Date Format](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-DateFormat): Change how dates are displayed in the interface
-* [Latex Support](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-LatexSupport): Add support for LaTeX notation rendering
-* [Reddit Image](https://github.com/aledeg/FreshRSS-extensions/tree/master/xExtension-RedditImage): Replace link to Reddit topic with resource link
+* [Date Format](https://github.com/aledeg/xExtension-DateFormat): Change how dates are displayed in the interface
+* [Latex Support](https://github.com/aledeg/xExtension-LatexSupport): Add support for LaTeX notation rendering
+* [Paywall](https://github.com/aledeg/xExtension-Paywall): Add title prefix on articles behind a paywall
+* [Reddit Image](https://github.com/aledeg/xExtension-RedditImage): Replace link to Reddit topic with resource link
 
 
 ### By [@Lapineige](https://github.com/lapineige), [@hkcomori](https://github.com/hkcomori)

--- a/extensions.json
+++ b/extensions.json
@@ -310,6 +310,17 @@
             "directory": "."
         },
         {
+            "name": "Paywall",
+            "author": "Alexis Degrugillier",
+            "description": "Modify the title when matching the configured domains, paywalls are the primary target but can be use for different use-cases.",
+            "version": "0.0.1",
+            "entrypoint": "Paywall",
+            "type": "user",
+            "url": "https://github.com/aledeg/xExtension-Paywall",
+            "method": "git",
+            "directory": "."
+        },
+        {
             "name": "Pocket Button",
             "author": "Christian Putzke",
             "description": "Add articles to Pocket with one simple button click or a keyboard shortcut.",


### PR DESCRIPTION
I've created a new extension to add a prefix on an article title when its URL matches the configured strings. I've added this new extension to the extension list.