### PR TITLE
Bump YouTube version

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -599,7 +599,7 @@
             "name": "YouTube Video Feed",
             "author": "Kevin Papst, Inverle",
             "description": "Embed YouTube feeds inside article content.",
-            "version": "0.2",
+            "version": "1.0.0",
             "entrypoint": "YouTube",
             "type": "user",
             "url": "https://github.com/FreshRSS/Extensions",

--- a/xExtension-YouTube/metadata.json
+++ b/xExtension-YouTube/metadata.json
@@ -2,7 +2,7 @@
 	"name": "YouTube Video Feed",
 	"author": "Kevin Papst, Inverle",
 	"description": "Embed YouTube feeds inside article content.",
-	"version": "0.2",
+	"version": "1.0.0",
 	"entrypoint": "YouTube",
 	"type": "user"
 }


### PR DESCRIPTION
Follow-up of https://github.com/FreshRSS/Extensions/pull/362 with likely wrong version number.
