### PR TITLE
Remove togglable menu extension from list

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [Nicolas Frandeboeuf](https://framagit.org/nicofrand)
 
 * [ThreePanesView](https://framagit.org/nicofrand/xextension-threepanesview): [Adds a third vertical pane along the articles list, to display the articles content](https://nicofrand.eu/freshrss-extension-threepanesview/).
-* [TogglableMenu](https://framagit.org/nicofrand/xextension-togglablemenu): Makes the menu always togglable, even on larger screens.
 
 
 ### By [@Lapineige](https://github.com/lapineige), [@hkcomori](https://github.com/hkcomori)

--- a/extensions.json
+++ b/extensions.json
@@ -13,17 +13,6 @@
             "directory": "."
         },
         {
-            "name": "Always togglable menu",
-            "author": "nicofrand",
-            "description": "This makes the icon to toggle the menu always shown, even on larger screens.",
-            "version": "1.2",
-            "entrypoint": "TogglableMenu",
-            "type": "user",
-            "url": "https://framagit.org/nicofrand/xextension-togglablemenu",
-            "method": "git",
-            "directory": "."
-        },
-        {
             "name": "ArticleSummary",
             "author": "Liang",
             "description": "A powerful article summarization plugin for FreshRSS that allows users to generate summaries using a language model API conforming to the OpenAI API specification.",

--- a/repositories.json
+++ b/repositories.json
@@ -26,9 +26,6 @@
 	"url": "https://framagit.org/nicofrand/xextension-threepanesview",
 	"type": "git"
 }, {
-	"url": "https://framagit.org/nicofrand/xextension-togglablemenu",
-	"type": "git"
-}, {
 	"url": "https://github.com/Korbak/freshrss-invidious",
 	"type": "git"
 }, {


### PR DESCRIPTION
This is now implemented in FreshRSS instead: https://github.com/FreshRSS/FreshRSS/pull/8201