### PR TITLE
New extension: Mark As Read Existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,3 +199,7 @@ There are some FreshRSS extensions out there, developed by community members:
 ### By [@deimosfr](https://github.com/deimosfr/)
 
 * [Ai Summary](https://github.com/deimosfr/xExtension-AiSummary): Summarize any article with one click using your favorite AI provider (OpenAI, Gemini, Claude and Ollama).
+
+### By [@bullitt186](https://github.com/bullitt186/)
+
+* [Mark As Read Existing](https://github.com/bullitt186/FreshRSS-MarkAsReadExisting): Periodically re-applies "Mark as read" filter rules to existing unread articles.

--- a/extensions.json
+++ b/extensions.json
@@ -310,6 +310,17 @@
             "directory": "xExtension-MarkPreviousAsRead"
         },
         {
+            "name": "Mark As Read Existing",
+            "author": "bullitt",
+            "description": "Periodically re-applies 'Mark as read' filter rules to existing articles",
+            "version": "0.1.0",
+            "entrypoint": "MarkAsReadExisting",
+            "type": "user",
+            "url": "https://github.com/bullitt186/FreshRSS-MarkAsReadExisting",
+            "method": "git",
+            "directory": "xExtension-MarkAsReadExisting"
+        },
+        {
             "name": "Mobile Scroll Menu",
             "author": "Marco Heizmann",
             "description": "Automatically hides the header menu on mobile phones, when scrolling down and shows it when scrolling up.",

--- a/repositories.json
+++ b/repositories.json
@@ -118,4 +118,7 @@
 }, {
 	"url": "https://github.com/deimosfr/xExtension-AiSummary",
 	"type": "git"
+}, {
+	"url": "https://github.com/bullitt186/FreshRSS-MarkAsReadExisting",
+	"type": "git"
 }]


### PR DESCRIPTION
## Mark As Read Existing

A FreshRSS extension that periodically re-applies "Mark as read" filter rules to existing unread articles.

### Problem

FreshRSS only applies "Mark as read" filter rules when new articles arrive during feed actualization. Time-based rules like `-pubdate:P7D/` (older than 7 days) never match existing articles because they were newer than 7 days when they first arrived.

### Solution

This extension hooks into the `freshrss_user_maintenance` cycle and re-evaluates all configured "Mark as read" filter rules against existing unread articles. It supports feed, category, and global filter levels with independent enable/disable toggles and configurable intervals.

### Features

- Three filter levels (feed/category/global), each independently configurable
- Configurable run intervals (default: 60 min each)
- Dry-run mode to preview matches without marking
- Run-now button for immediate execution
- Per-filter logging with article counts

### Repository

https://github.com/bullitt186/FreshRSS-MarkAsReadExisting

### Changes in this PR

- `repositories.json`: Added repository URL
- `extensions.json`: Added extension entry (alphabetically between "Mark Previous as Read" and "Mobile Scroll Menu")
- `README.md`: Added author section with extension description
