### PR TITLE
Add featurecreep-cron extensions (5 extensions)

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,14 @@ There are some FreshRSS extensions out there, developed by community members:
 
 * [Share To Linkwarden](https://github.com/daften/xExtension-ShareToLinkwarden/): Allows sharing items directly to a self-hosted Linkwarden instance.
 
+### By [@featurecreep-cron](https://github.com/featurecreep-cron)
+
+* [Extension Manager](https://github.com/featurecreep-cron/freshrss-extensions/tree/main/xExtension-ExtensionManager): Install, update, and remove extensions from the settings page.
+* [Recently Read](https://github.com/featurecreep-cron/freshrss-extensions/tree/main/xExtension-RecentlyRead): Adds a Recently Read view to quickly find articles you've already read.
+* [Right-Click Actions](https://github.com/featurecreep-cron/freshrss-extensions/tree/main/xExtension-RightClickActions): Adds context menus to articles, feeds, and categories.
+* [Silent Refresh](https://github.com/featurecreep-cron/freshrss-extensions/tree/main/xExtension-SilentRefresh): Updates unread counts without interrupting your reading.
+* [Sticky Reader](https://github.com/featurecreep-cron/freshrss-extensions/tree/main/xExtension-StickyReader): Scroll straight to articles, keep controls within reach, read distraction-free.
+
 ### By [@fengchang](https://github.com/fengchang)
 
 * [Feed Digest](https://github.com/fengchang/xExtension-FeedDigest): Automatically summarize RSS articles using OpenAI-compatible LLM APIs.

--- a/extensions.json
+++ b/extensions.json
@@ -123,6 +123,17 @@
             "directory": "."
         },
         {
+            "name": "Extension Manager",
+            "author": "featurecreep-cron",
+            "description": "Install, update, and remove extensions from the settings page",
+            "version": "0.2.4",
+            "entrypoint": "ExtensionManager",
+            "type": "user",
+            "url": "https://github.com/featurecreep-cron/freshrss-extensions",
+            "method": "git",
+            "directory": "xExtension-ExtensionManager"
+        },
+        {
             "name": "Feed Digest",
             "author": "Chang Feng",
             "description": "Automatically summarizes newly retrieved RSS articles using LLM APIs (OpenAI-compatible)",
@@ -398,6 +409,17 @@
             "directory": "."
         },
         {
+            "name": "Recently Read",
+            "author": "featurecreep-cron",
+            "description": "Adds a Recently Read view to quickly find articles you've already read",
+            "version": "0.1.2",
+            "entrypoint": "RecentlyRead",
+            "type": "user",
+            "url": "https://github.com/featurecreep-cron/freshrss-extensions",
+            "method": "git",
+            "directory": "xExtension-RecentlyRead"
+        },
+        {
             "name": "Readeck Button",
             "author": "Joedmin",
             "description": "Add articles to Readeck with one simple button click or a keyboard shortcut.",
@@ -429,6 +451,17 @@
             "url": "https://github.com/aledeg/xExtension-RedditImage",
             "method": "git",
             "directory": "."
+        },
+        {
+            "name": "Right-Click Actions",
+            "author": "featurecreep-cron",
+            "description": "Adds context menus to articles, feeds, and categories",
+            "version": "0.1.2",
+            "entrypoint": "RightClickActions",
+            "type": "user",
+            "url": "https://github.com/featurecreep-cron/freshrss-extensions",
+            "method": "git",
+            "directory": "xExtension-RightClickActions"
         },
         {
             "name": "Remove emojis",
@@ -486,6 +519,17 @@
             "directory": "xExtension-showFeedID"
         },
         {
+            "name": "Silent Refresh",
+            "author": "featurecreep-cron",
+            "description": "Updates unread counts without interrupting your reading",
+            "version": "0.1.1",
+            "entrypoint": "SilentRefresh",
+            "type": "user",
+            "url": "https://github.com/featurecreep-cron/freshrss-extensions",
+            "method": "git",
+            "directory": "xExtension-SilentRefresh"
+        },
+        {
             "name": "Smart Mobile Menu",
             "author": "Marco Heizmann",
             "description": "Minimizes the required button space and groups buttons.",
@@ -506,6 +550,17 @@
             "url": "https://github.com/FreshRSS/Extensions",
             "method": "git",
             "directory": "xExtension-StickyFeeds"
+        },
+        {
+            "name": "Sticky Reader",
+            "author": "featurecreep-cron",
+            "description": "Scroll straight to articles, keep controls within reach, read distraction-free",
+            "version": "0.2.4",
+            "entrypoint": "StickyReader",
+            "type": "user",
+            "url": "https://github.com/featurecreep-cron/freshrss-extensions",
+            "method": "git",
+            "directory": "xExtension-StickyReader"
         },
         {
             "name": "Theme Mode Synchronizer",

--- a/repositories.json
+++ b/repositories.json
@@ -115,4 +115,7 @@
 }, {
 	"url": "https://github.com/bullitt186/FreshRSS-MarkAsReadExisting",
 	"type": "git"
+}, {
+	"url": "https://github.com/featurecreep-cron/freshrss-extensions",
+	"type": "git"
 }]


### PR DESCRIPTION
Adds 5 extensions from [`featurecreep-cron/freshrss-extensions`](https://github.com/featurecreep-cron/freshrss-extensions):

| Extension | Description |
|-----------|-------------|
| **Extension Manager** | Install, update, and remove extensions from the settings page |
| **Recently Read** | Adds a Recently Read view to quickly find articles you've already read |
| **Right-Click Actions** | Adds context menus to articles, feeds, and categories |
| **Silent Refresh** | Updates unread counts without interrupting your reading |
| **Sticky Reader** | Scroll straight to articles, keep controls within reach, read distraction-free |

All extensions pass PHPStan level 0, use correct FreshRSS API signatures, and support both light and dark themes.

Changes:
- `repositories.json`: Added repo URL
- `README.md`: Added author section with 5 extensions
- `extensions.json`: Added 5 entries in alphabetical order