### PR TITLE
Fix freshrss-greader-redate repo

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -222,6 +222,17 @@
             "directory": "."
         },
         {
+            "name": "GReader Redate",
+            "author": "Julien Avérous",
+            "description": "Use published date instead of fetching date.",
+            "version": "1.3",
+            "entrypoint": "GReaderRedate",
+            "type": "user",
+            "url": "https://codeberg.org/javerous/freshrss-greader-redate",
+            "method": "git",
+            "directory": "xExtension-GReaderRedate"
+        },
+        {
             "name": "Image Cache",
             "author": "Victrid",
             "description": "Cache feed images on your own facility or Cloudflare cache.",

--- a/repositories.json
+++ b/repositories.json
@@ -44,7 +44,7 @@
 	"url": "https://github.com/tunbridgep/freshrss-invidious",
 	"type": "git"
 }, {
-	"url": "https://github.com/javerous/freshrss-greader-redate",
+	"url": "https://codeberg.org/javerous/freshrss-greader-redate",
 	"type": "git"
 }, {
 	"url": "https://github.com/kapdap/freshrss-extensions",


### PR DESCRIPTION
The extension moved address some time ago. The extension is archived though, so it might have to be removed (I have not tested whether it is still working / needed).
