### PR TITLE
[Webhook extension] Fix test request form button

### DIFF
--- a/xExtension-Webhook/configure.phtml
+++ b/xExtension-Webhook/configure.phtml
@@ -145,7 +145,7 @@ declare(strict_types=1);
 		<div class="group-controls">
 			<button type="submit" class="btn btn-important"><?= _t('gen.action.submit') ?></button>
 			<button type="reset" class="btn"><?= _t('gen.action.cancel') ?></button>
-			<button type="menu" class="btn"><?= _t('ext.webhook.save_and_send_test_req') ?></button>
+			<button type="submit" class="btn" name="test_request" value="true"><?= _t('ext.webhook.save_and_send_test_req') ?></button>
 		</div>
 	</div>
 </form>

--- a/xExtension-Webhook/metadata.json
+++ b/xExtension-Webhook/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Webhook",
 	"author": "Lukas Melega, Ryahn",
 	"description": "Send custom webhook when new article appears (and matches custom criteria)",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"entrypoint": "Webhook",
 	"type": "user",
 	"compatibility": "1.28.2"


### PR DESCRIPTION
The "Save and send test request" button is currently not working. To execute the test request, [line 93](https://github.com/FreshRSS/Extensions/blob/53b618bbbf32acb79ba18ff7c28ea7b590145745/xExtension-Webhook/extension.php#L93) of the extension.php file checks that the test_request parameter is not empty.