### PR TITLE
[xExtension-YouTube] Add optional responsive player sizing

### DIFF
--- a/xExtension-YouTube/configure.phtml
+++ b/xExtension-YouTube/configure.phtml
@@ -6,6 +6,13 @@ declare(strict_types=1);
 	<input type="hidden" name="_csrf" value="<?= FreshRSS_Auth::csrfToken() ?>" />
 	<div class="form-group">
 
+		<div class="group-controls">
+			<label class="checkbox" for="yt_autosize">
+				<input type="checkbox" id="yt_autosize" name="yt_autosize" <?= $this->isAutoSize() ? 'checked="checked"' : '' ?> />
+				<?= _t('ext.yt_videos.autosize') ?>
+			</label>
+		</div>
+
 		<label class="group-name" for="yt_height"><?= _t('ext.yt_videos.height') ?></label>
 		<div class="group-controls">
 			<input type="number" id="yt_height" name="yt_height" value="<?= $this->getHeight() ?>" min="50" />

--- a/xExtension-YouTube/extension.php
+++ b/xExtension-YouTube/extension.php
@@ -10,6 +10,10 @@ declare(strict_types=1);
 final class YouTubeExtension extends Minz_Extension
 {
 	/**
+	 * Whether the video player should use responsive sizing
+	 */
+	private bool $autoSize = false;
+	/**
 	 * Video player width
 	 */
 	private int $width = 560;
@@ -35,6 +39,7 @@ final class YouTubeExtension extends Minz_Extension
 	 */
 	#[\Override]
 	public function init(): void {
+		Minz_View::appendStyle($this->getFileUrl('style.css'));
 		$this->registerHook('entry_before_display', [$this, 'embedYouTubeVideo']);
 		$this->registerHook('check_url_before_add', [self::class, 'convertYoutubeFeedUrl']);
 		$this->registerHook('custom_favicon_hash', [$this, 'iconHashParams']);
@@ -312,6 +317,11 @@ final class YouTubeExtension extends Minz_Extension
 			return;
 		}
 
+		$autoSize = FreshRSS_Context::userConf()->attributeBool('yt_player_autosize');
+		if ($autoSize !== null) {
+			$this->autoSize = $autoSize;
+		}
+
 		$width = FreshRSS_Context::userConf()->attributeInt('yt_player_width');
 		if ($width !== null) {
 			$this->width = $width;
@@ -336,6 +346,14 @@ final class YouTubeExtension extends Minz_Extension
 		if ($noCookie !== null) {
 			$this->useNoCookie = $noCookie;
 		}
+	}
+
+	/**
+	 * Returns whether responsive sizing is enabled for the video player iframe.
+	 * You have to call loadConfigValues() before this one, otherwise you get the default value.
+	 */
+	public function isAutoSize(): bool {
+		return $this->autoSize;
 	}
 
 	/**
@@ -446,11 +464,11 @@ final class YouTubeExtension extends Minz_Extension
 	 */
 	public function getHtml(FreshRSS_Entry $entry, string $url): string {
 		$content = '';
+		$iframeAttributes = $this->autoSize
+			? 'class="youtube-plugin-video yt-player-autosize"'
+			: 'class="youtube-plugin-video" width="' . $this->width . '" height="' . $this->height . '"';
 
-		$iframe = '<iframe class="youtube-plugin-video"
-				style="height: ' . $this->height . 'px; width: ' . $this->width . 'px;"
-				width="' . $this->width . '"
-				height="' . $this->height . '"
+		$iframe = '<iframe ' . $iframeAttributes . '
 				src="' . $url . '"
 				frameborder="0"
 				referrerpolicy="strict-origin-when-cross-origin"
@@ -570,6 +588,7 @@ final class YouTubeExtension extends Minz_Extension
 					$this->resetAllIcons();
 					break;
 			}
+			FreshRSS_Context::userConf()->_attribute('yt_player_autosize', Minz_Request::paramBoolean('yt_autosize'));
 			FreshRSS_Context::userConf()->_attribute('yt_player_height', Minz_Request::paramInt('yt_height'));
 			FreshRSS_Context::userConf()->_attribute('yt_player_width', Minz_Request::paramInt('yt_width'));
 			FreshRSS_Context::userConf()->_attribute('yt_show_content', Minz_Request::paramBoolean('yt_show_content'));

--- a/xExtension-YouTube/i18n/de/ext.php
+++ b/xExtension-YouTube/i18n/de/ext.php
@@ -2,6 +2,7 @@
 
 return array(
 	'yt_videos' => array(
+		'autosize' => 'Automatische Größe des Players',
 		'height' => 'Höhe des Players',
 		'width' => 'Breite des Players',
 		'show_content' => 'Zeige den Inhalt des Feeds an',

--- a/xExtension-YouTube/i18n/en/ext.php
+++ b/xExtension-YouTube/i18n/en/ext.php
@@ -2,6 +2,7 @@
 
 return array(
 	'yt_videos' => array(
+		'autosize' => 'Automatically size the player',
 		'height' => 'Player height',
 		'width' => 'Player width',
 		'show_content' => 'Display the feeds content',

--- a/xExtension-YouTube/i18n/fr/ext.php
+++ b/xExtension-YouTube/i18n/fr/ext.php
@@ -2,6 +2,7 @@
 
 return array(
 	'yt_videos' => array(
+		'autosize' => 'Taille automatique du lecteur',
 		'height' => 'Hauteur du lecteur',
 		'width' => 'Largeur du lecteur',
 		'show_content' => 'Afficher le contenu du flux',

--- a/xExtension-YouTube/i18n/pl/ext.php
+++ b/xExtension-YouTube/i18n/pl/ext.php
@@ -2,6 +2,7 @@
 
 return array(
 	'yt_videos' => array(
+		'autosize' => 'Automatyczny rozmiar odtwarzacza',
 		'height' => 'Wysokość odtwarzacza wideo',
 		'width' => 'Szerokość odtwarzacza wideo',
 		'show_content' => 'Wyświetlaj zawartość kanałów',

--- a/xExtension-YouTube/i18n/tr/ext.php
+++ b/xExtension-YouTube/i18n/tr/ext.php
@@ -2,6 +2,7 @@
 
 return array(
 	'yt_videos' => array(
+		'autosize' => 'Oynatıcıyı otomatik boyutlandır',
 		'height' => 'Oynatıcı yükseklik',
 		'width' => 'Oynatıcı genişlik',
 		'show_content' => 'Yayın içeriğini görüntüle',

--- a/xExtension-YouTube/metadata.json
+++ b/xExtension-YouTube/metadata.json
@@ -2,7 +2,7 @@
 	"name": "YouTube Video Feed",
 	"author": "Kevin Papst, Inverle",
 	"description": "Embed YouTube feeds inside article content.",
-	"version": "1.2.0",
+	"version": "1.3.0",
 	"entrypoint": "YouTube",
 	"type": "user"
 }

--- a/xExtension-YouTube/static/style.css
+++ b/xExtension-YouTube/static/style.css
@@ -1,0 +1,4 @@
+.yt-player-autosize {
+	width: 100%;
+	aspect-ratio: 16 / 9;
+}


### PR DESCRIPTION
## Summary

- add an opt-in responsive sizing setting for the YouTube and PeerTube players
- preserve the existing `youtube-plugin-video` class and fixed-size behavior by default
- move player sizing out of the inline `style` attribute so it works with FreshRSS CSP
- keep the `referrerpolicy` introduced in #382

This takes over the work from #291 and applies its review feedback to the current implementation.

## Behavior

When automatic sizing is enabled, the player uses the existing `youtube-plugin-video` class together with `yt-player-autosize`, which applies a full-width 16:9 aspect ratio. When it is disabled or unset, the configured `width` and `height` attributes are preserved.

## Validation

- `npm run eslint`
- `npx stylelint "**/*.css"`
- `npm run markdownlint`
- reviewed the generated iframe branches for YouTube, youtube-nocookie, PeerTube, and original-content handling

PHPStan and PHPCS were not run locally because PHP and `make` are unavailable on PATH and Docker Desktop could not start. They are expected to run in GitHub Actions.