### PR TITLE
[Share By Email] Preserve special characters in email subjects

### DIFF
--- a/xExtension-ShareByEmail/Controllers/shareByEmailController.php
+++ b/xExtension-ShareByEmail/Controllers/shareByEmailController.php
@@ -70,7 +70,7 @@ final class FreshExtension_shareByEmail_Controller extends Minz_ActionController
 
 		if (Minz_Request::isPost()) {
 			$this->view->to = $to = Minz_Request::paramString('to');
-			$this->view->subject = $subject = Minz_Request::paramString('subject');
+			$this->view->subject = $subject = Minz_Request::paramString('subject', plaintext: true);
 			$this->view->content = $content = Minz_Request::paramString('content');
 
 			if ($to == "" || $subject == "" || $content == "") {

--- a/xExtension-ShareByEmail/metadata.json
+++ b/xExtension-ShareByEmail/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Share By Email",
 	"author": "Marien Fressinaud",
 	"description": "Improve the sharing by email system.",
-	"version": "0.3.3",
+	"version": "0.3.4",
 	"entrypoint": "ShareByEmail",
 	"type": "user"
 }


### PR DESCRIPTION
## Summary

- preserve special characters in Share By Email subjects instead of XML-encoding them
- bump the Share By Email extension version to 0.3.4

## Root cause

`Minz_Request::paramString()` XML-encodes special characters by default. As a result, a subject such as `"word"` was passed to PHPMailer as `&quot;word&quot;` and displayed that way by email clients.

Reading the subject with `plaintext: true` keeps the original text for PHPMailer, including quotation marks, ampersands, and non-ASCII characters.

Fixes #342

## Validation

- confirmed the default and `plaintext: true` behavior in `Minz_Request::paramString()`
- reviewed the subject data flow from the POST parameter to `ShareByEmail\mailers\Share` and PHPMailer
- confirmed the diff is limited to the Share By Email controller and metadata

PHPStan and PHPCS were not run locally because PHP is unavailable in the local environment. They are expected to run in GitHub Actions.