### PR TITLE
[Share By Email] Fix view model autoloading

### DIFF
--- a/xExtension-ShareByEmail/Controllers/shareByEmailController.php
+++ b/xExtension-ShareByEmail/Controllers/shareByEmailController.php
@@ -6,13 +6,13 @@ final class FreshExtension_shareByEmail_Controller extends Minz_ActionController
 	public ?Minz_Extension $extension;
 
 	/**
-	 * @var ShareByEmail\mailers\View
+	 * @var ShareByEmail\Models\View
 	 * @phpstan-ignore property.phpDocType
 	 */
 	protected $view;
 
 	public function __construct() {
-		parent::__construct(ShareByEmail\mailers\View::class);
+		parent::__construct(ShareByEmail\Models\View::class);
 	}
 
 	#[\Override]

--- a/xExtension-ShareByEmail/Models/View.php
+++ b/xExtension-ShareByEmail/Models/View.php
@@ -2,12 +2,13 @@
 
 declare(strict_types=1);
 
-namespace ShareByEmail\mailers;
+namespace ShareByEmail\Models;
 
 final class View extends \Minz_View {
 
 	public ?\FreshRSS_Entry $entry = null;
 	public string $content = '';
+	public string $rss_url = '';
 	public string $subject = '';
 	public string $to = '';
 }

--- a/xExtension-ShareByEmail/mailers/Share.php
+++ b/xExtension-ShareByEmail/mailers/Share.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace ShareByEmail\mailers;
 
+use ShareByEmail\Models\View;
+
 final class Share extends \Minz_Mailer {
 
 	/**

--- a/xExtension-ShareByEmail/metadata.json
+++ b/xExtension-ShareByEmail/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Share By Email",
 	"author": "Marien Fressinaud",
 	"description": "Improve the sharing by email system.",
-	"version": "0.3.4",
+	"version": "0.3.5",
 	"entrypoint": "ShareByEmail",
 	"type": "user"
 }

--- a/xExtension-ShareByEmail/views/shareByEmail/share.phtml
+++ b/xExtension-ShareByEmail/views/shareByEmail/share.phtml
@@ -1,6 +1,6 @@
 <?php
 	declare(strict_types=1);
-	/** @var ShareByEmail\mailers\View $this */
+	/** @var ShareByEmail\Models\View $this */
 ?>
 <div class="post">
 	<h1><?= _t('shareByEmail.share.title') ?></h1>

--- a/xExtension-ShareByEmail/views/share_mailer/article.txt.php
+++ b/xExtension-ShareByEmail/views/share_mailer/article.txt.php
@@ -2,5 +2,5 @@
 
 declare(strict_types=1);
 
-/** @var ShareByEmail\mailers\View $this */
+/** @var ShareByEmail\Models\View $this */
 echo $this->content;


### PR DESCRIPTION
## Summary

- align the Share By Email view namespace with its `Models/View.php` path
- use the typed view model in both the controller and mailer
- declare `rss_url` for compatibility with the legacy `simple` layout
- bump the Share By Email extension version to 0.3.5

## Root cause

The view class was stored in `Models/View.php` but declared and referenced as `ShareByEmail\mailers\View`. The extension autoloader therefore looked for a non-existent `mailers/View.php` file. When loading failed, the controller and mailer fell back to the base `Minz_View`, causing dynamic-property deprecation warnings on PHP 8.2 and an undefined `rss_url` warning in the legacy `simple` layout.

Using `ShareByEmail\Models\View` makes the namespace resolve to the existing file and keeps all view data on declared typed properties.

Fixes #210
Fixes #363

## Validation

- confirmed every Share By Email view reference uses `ShareByEmail\Models\View`
- confirmed no references to `ShareByEmail\mailers\View` remain
- confirmed `entry`, `to`, `subject`, `content`, and `rss_url` are declared on the view model
- confirmed the diff is limited to Share By Email view-related files and metadata

PHPStan and PHPCS were not run locally because PHP is unavailable in the local environment. They are expected to run in GitHub Actions.