### PR TITLE
[Colorful List] Preserve article background on hover

### DIFF
--- a/xExtension-ColorfulList/extension.php
+++ b/xExtension-ColorfulList/extension.php
@@ -6,6 +6,7 @@ final class ColorfulListExtension extends Minz_Extension
 {
 	#[\Override]
 	public function init(): void {
+		Minz_View::appendStyle($this->getFileUrl('style.css'));
 		Minz_View::appendScript($this->getFileUrl('script.js'));
 	}
 }

--- a/xExtension-ColorfulList/metadata.json
+++ b/xExtension-ColorfulList/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Colorful List",
 	"author": "Claud Xiao",
 	"description": "Colorful Entry Title based on RSS source",
-	"version": "0.3.2",
+	"version": "0.3.3",
 	"entrypoint": "ColorfulList",
 	"type": "user"
 }

--- a/xExtension-ColorfulList/static/script.js
+++ b/xExtension-ColorfulList/static/script.js
@@ -25,7 +25,7 @@ function colorize(mList) {
 	const entry = document.querySelectorAll('.flux_header');
 	entry.forEach((e, i) => {
 		const cl = stringToColour(e.querySelector('.website').textContent) + '12';
-		e.style.background = cl;
+		e.style.setProperty('--colorful-list-background', cl);
 	});
 }
 

--- a/xExtension-ColorfulList/static/style.css
+++ b/xExtension-ColorfulList/static/style.css
@@ -1,0 +1,7 @@
+.flux_header {
+	background-color: var(--colorful-list-background) !important;
+}
+
+.flux:hover .flux_header .title {
+	background-color: var(--colorful-list-background) !important;
+}


### PR DESCRIPTION
## Summary

- move the generated feed color from an inline `background` declaration to a CSS custom property
- apply that color consistently to the article header and title while hovering
- register the extension stylesheet and bump Colorful List to 0.3.3

Fixes #203

## Root cause

Colorful List set the article header background through an inline shorthand declaration. FreshRSS themes change both the header and title backgrounds on hover, but the inline header background won the cascade while the title received the theme hover color. This produced two different backgrounds within the same row.

## Visual comparison

The screenshots use the same FreshRSS feed, Origine light theme, 1280×720 viewport, and first article. Because the available browser runner cannot activate the CSS `:hover` pseudo-class, a test-only stylesheet replaced `:hover` with a class for the first row. The stylesheet used the exact Origine hover declarations and was served only by the local test proxy; it is not part of this PR.

### Before

_The title area uses the theme hover color while the rest of the row retains the generated feed color._

![Before: the hovered title uses a different background](https://raw.githubusercontent.com/JamBalaya56562/Extensions/dc1e98c29be0fc50bb7d543c91b3d675015bb7e1/pr-assets/491/colorful-list-before-hover.png)

### After

_The title, header, and date area retain one continuous generated feed color._

![After: the hovered title and article row use one continuous background](https://raw.githubusercontent.com/JamBalaya56562/Extensions/dc1e98c29be0fc50bb7d543c91b3d675015bb7e1/pr-assets/491/colorful-list-after-hover.png)

Computed colors for the simulated hovered first row:

- Before: header `rgba(139, 178, 195, 0.07)`; title `rgb(250, 238, 232)`
- After: header and title `rgba(139, 178, 195, 0.07)`

## Validation

- `npm run eslint`
- `npx stylelint "**/*.css"`
- `npm run markdownlint`
- verified initial entries and dynamically loaded entries continue receiving the CSS custom property through the existing observer
- verified the normal and simulated-hover states in FreshRSS 1.29.2-dev with Colorful List enabled
