### PR TITLE
[Share By Email] Load translations on configuration page

### DIFF
--- a/xExtension-ShareByEmail/extension.php
+++ b/xExtension-ShareByEmail/extension.php
@@ -25,6 +25,11 @@ final class ShareByEmailExtension extends Minz_Extension {
 		spl_autoload_register(array($this, 'loader'));
 	}
 
+	#[\Override]
+	public function handleConfigureAction(): void {
+		$this->registerTranslates();
+	}
+
 	public function loader(string $class_name): void {
 		if (strpos($class_name, 'ShareByEmail') === 0) {
 			$class_name = substr($class_name, 13);

--- a/xExtension-ShareByEmail/metadata.json
+++ b/xExtension-ShareByEmail/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Share By Email",
 	"author": "Marien Fressinaud",
 	"description": "Improve the sharing by email system.",
-	"version": "0.3.5",
+	"version": "0.3.6",
 	"entrypoint": "ShareByEmail",
 	"type": "user"
 }


### PR DESCRIPTION
## Summary

- register Share By Email translations when FreshRSS opens the extension configuration page
- keep the existing translation registration during normal extension initialization
- bump the extension version to 0.3.6

Fixes #390

## Root cause

FreshRSS invokes `handleConfigureAction()` when rendering an extension's configuration page. Share By Email only registered its translations from `init()`, so the configuration template could render before the extension translation namespace was available and expose keys such as `shareByEmail.share.manage.mailer`.

## Visual comparison

Both screenshots use FreshRSS 1.29.2-dev, the Origine light theme, English UI, and a 1280×720 viewport.

| Before | After |
| --- | --- |
| ![Before: untranslated Share By Email configuration keys](https://raw.githubusercontent.com/JamBalaya56562/Extensions/3d4ea9ac28596076477c58f95861e4975ccee517/pr-assets/share-by-email-config-translations/before.png) | ![After: translated Share By Email configuration labels](https://raw.githubusercontent.com/JamBalaya56562/Extensions/3d4ea9ac28596076477c58f95861e4975ccee517/pr-assets/share-by-email-config-translations/after.png) |

## Validation

- confirmed the configuration GET renders `Mailing system`, the active mailer, and the translated help text
- confirmed normal extension initialization still registers translations for sharing and feedback messages
- `npm run eslint`
- `npx stylelint "**/*.css"`
- `npm run markdownlint`
