### PR TITLE
[xExtension-Webhook] Add freshrss username placeholder

### DIFF
--- a/xExtension-Webhook/README.md
+++ b/xExtension-Webhook/README.md
@@ -62,7 +62,8 @@ Customize the webhook payload using placeholders:
 	"date": "{date}",
 	"timestamp": "{date_timestamp}",
 	"author": "{author}",
-	"tags": "{tags}"
+	"tags": "{tags}",
+	"user": "{user}"
 }
 ```
 
@@ -80,6 +81,7 @@ Customize the webhook payload using placeholders:
 | `{feed_url}` | Feed URL |
 | `{thumbnail_url}` | Thumbnail (image) URL |
 | `{tags}` | Article tags (separated by " #") |
+| `{user}` |  Username in FreshRSS |
 
 ## 🎯 Use Cases
 

--- a/xExtension-Webhook/README.md
+++ b/xExtension-Webhook/README.md
@@ -81,7 +81,7 @@ Customize the webhook payload using placeholders:
 | `{feed_url}` | Feed URL |
 | `{thumbnail_url}` | Thumbnail (image) URL |
 | `{tags}` | Article tags (separated by " #") |
-| `{user}` |  Username in FreshRSS |
+| `{user}` | Username in FreshRSS |
 
 ## 🎯 Use Cases
 

--- a/xExtension-Webhook/configure.phtml
+++ b/xExtension-Webhook/configure.phtml
@@ -113,6 +113,10 @@ declare(strict_types=1);
 									<td><code>{tags}</code></td>
 									<td><?= _t('ext.webhook.http_body_placeholder_tags_description') ?></td>
 								</tr>
+								<tr>
+									<td><code>{user}</code></td>
+									<td><?= _t('ext.webhook.http_body_placeholder_user_description') ?></td>
+								</tr>
 							</table>
 						</div>
 					</div>

--- a/xExtension-Webhook/extension.php
+++ b/xExtension-Webhook/extension.php
@@ -226,6 +226,7 @@ class WebhookExtension extends Minz_Extension {
 					'{date_user_modified}' => $entry->lastUserModified() === null ? null : timestampToMachineDate($entry->lastUserModified()),
 					'{author}' => htmlspecialchars_decode($entry->authors(true), ENT_QUOTES),
 					'{tags}' => htmlspecialchars_decode($entry->tags(true), ENT_QUOTES),
+					'{user}' => Minz_User::name() ?? '',
 				];
 
 				$body = $this->replacePlaceholdersRecursive($body, $replacements);

--- a/xExtension-Webhook/i18n/en/ext.php
+++ b/xExtension-Webhook/i18n/en/ext.php
@@ -21,6 +21,7 @@ return array(
 		'http_body_placeholder_feed_description' => 'Name of the feed',
 		'http_body_placeholder_feed_url_description' => 'URL of the feed',
 		'http_body_placeholder_tags_description' => 'Article tags (string, separated by " #")',
+		'http_body_placeholder_user_description' => 'Username in FreshRSS',
 		'http_body_placeholder_date_published_description' => 'Publication date (ISO 8601)',
 		'http_body_placeholder_date_received_description' => 'Date received by FreshRSS (ISO 8601)',
 		'http_body_placeholder_date_modified_description' => 'Last modified date (ISO 8601, null if never modified)',

--- a/xExtension-Webhook/i18n/fr/ext.php
+++ b/xExtension-Webhook/i18n/fr/ext.php
@@ -21,6 +21,7 @@ return array(
 		'http_body_placeholder_feed_description' => 'Nom du flux',
 		'http_body_placeholder_feed_url_description' => 'URL du flux',
 		'http_body_placeholder_tags_description' => 'Étiquettes de l’article (chaîne, séparées par « # »)',
+		'http_body_placeholder_user_description' => 'Utilisateur chez FreshRSS',
 		'http_body_placeholder_date_published_description' => 'Date de publication (ISO 8601)',
 		'http_body_placeholder_date_received_description' => 'Date de réception par FreshRSS (ISO 8601)',
 		'http_body_placeholder_date_modified_description' => 'Date de dernière modification (ISO 8601, null si jamais modifié)',

--- a/xExtension-Webhook/metadata.json
+++ b/xExtension-Webhook/metadata.json
@@ -2,7 +2,7 @@
 	"name": "Webhook",
 	"author": "Lukas Melega, Ryahn",
 	"description": "Send custom webhook when new article appears (and matches custom criteria)",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"entrypoint": "Webhook",
 	"type": "user",
 	"compatibility": "1.28.2"


### PR DESCRIPTION
## Summary

- Add a placeholder to send the FreshRSS username to the webhook

## Root Cause

If a single service consumes all FreshRSS webhooks, and there is more than one registered user, there is no way to distinguish which user the webhook event belongs to.

My scenario: I use n8n to connect to the FreshRSS webhook, it will generate an NTFY notification and it will be sent to the channel according to the username (each user will see their own notifications).

## Images

<img width="741" height="893" alt="image" src="https://github.com/user-attachments/assets/32beeb64-f1da-457a-a9ad-f18425bb70a4" />
<img width="562" height="676" alt="image" src="https://github.com/user-attachments/assets/44f1608e-59a5-4d94-9a57-4d22c626e597" />
