### PR TITLE
[LLM Classification] Fix: Strip prefix from existing tags before re-adding in LLM classification

### DIFF
--- a/xExtension-LlmClassification/extension.php
+++ b/xExtension-LlmClassification/extension.php
@@ -443,6 +443,9 @@ final class LlmClassificationExtension extends Minz_Extension {
 						$existingTags,
 						static fn(string $tag) => str_starts_with($tag, $prefix)
 					));
+					// Strip the prefix from tags before re-adding them (will be re-applied in applyClassification)
+					$prefixLength = strlen($prefix);
+					$existingTags = array_map(static fn(string $tag) => substr($tag, $prefixLength), $existingTags);
 				}
 				$classification = [
 					'tags' => $existingTags,


### PR DESCRIPTION
When filtering tags by prefix, the prefix was being preserved on existing tags before they were re-added. This caused the prefix to be duplicated when applyClassification re-applied it. Now we strip the prefix from existing tags before re-adding them, preventing the duplication issue.

Closes #496