### PR TITLE
Add Mark Feed Read On Badge Click extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,7 @@ There are some FreshRSS extensions out there, developed by community members.
 ### By [@sanpo](https://codeberg.org/sanpo), [Web](https://sanpo.land)
 
 * [Apple Music Artist](https://codeberg.org/sanpo/xExtension-AppleMusicArtist): Subscribe to an artist's releases by their Apple Music artist page URL.
+
+### By [@StathisZ](https://github.com/StathisZ)
+
+* [Mark Feed Read On Badge Click](https://github.com/StathisZ/freshrss-mark-read-on-click): Click a feed's unread-count badge in the sidebar to mark all its articles as read.

--- a/repositories.json
+++ b/repositories.json
@@ -130,4 +130,7 @@
 }, {
 	"url": "https://codeberg.org/sanpo/xExtension-AppleMusicArtist",
 	"type": "git"
+}, {
+	"url": "https://github.com/StathisZ/freshrss-mark-read-on-click",
+	"type": "git"
 }]


### PR DESCRIPTION
Adds a third-party extension: clicking a feed's unread-count badge in the sidebar marks all of that feed's articles as read, instead of requiring you to open the feed and use the separate "mark as read" button.

This differs from two existing extensions that do something adjacent:
- kalvn's Mark Previous as Read adds a per-entry footer button that marks earlier entries read.
- bullitt186's Mark As Read Existing periodically re-applies "mark as read" filter rules.

This extension instead intercepts clicks on the sidebar's unread badge directly, no filter rules or per-entry buttons involved.

Repo: https://github.com/StathisZ/freshrss-mark-read-on-click