### PR TITLE
Add Translate Google extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,3 +246,7 @@ There are some FreshRSS extensions out there, developed by community members.
 ### By [@chenhaoc](https://github.com/chenhaoc)
 
 * [Title Dedup](https://github.com/chenhaoc/freshrss-dedup-extension): Mark target feed entries as read when the same title already exists in source feeds.
+
+### By [@profduweb](https://github.com/profduweb)
+
+* [Translate Google](https://github.com/profduweb/xExtension-TranslateGoogle): Open articles in Google Translate from the native article toolbar with a configurable target language.

--- a/repositories.json
+++ b/repositories.json
@@ -136,4 +136,7 @@
 }, {
 	"url": "https://github.com/chenhaoc/freshrss-dedup-extension",
 	"type": "git"
+}, {
+	"url": "https://github.com/profduweb/xExtension-TranslateGoogle",
+	"type": "git"
 }]


### PR DESCRIPTION
## Summary

- list Translate Google as a third-party FreshRSS extension;
- register its repository in `repositories.json`;
- add the extension and its author to the community extensions section.

## Why

Translate Google adds a translation action to the native upper article toolbar. Clicking it opens the original article in Google Translate. Each FreshRSS user can choose a target language in the extension settings, with French as the default.

The extension uses FreshRSS' native toolbar layout, supports dynamically loaded entries, works in desktop and mobile layouts, and requires no API key.

## User impact

Users can translate an article with one click while keeping the original FreshRSS entry unchanged. The original article URL is sent to Google only after the user explicitly clicks the translation action.

## Validation

- tested with FreshRSS 1.29.1;
- tested in desktop and compact mobile layouts;
- PHP syntax validation passed for all extension PHP files;
- JavaScript syntax validation passed with Node.js 22;
- `repositories.json` passes JSON validation;
- FreshRSS remained healthy after installation and activation.

Repository: https://github.com/profduweb/xExtension-TranslateGoogle
