### PR TITLE
Add Broad Site Icon Fetcher extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,3 +250,7 @@ There are some FreshRSS extensions out there, developed by community members.
 ### By [@profduweb](https://github.com/profduweb)
 
 * [Translate Google](https://github.com/profduweb/xExtension-TranslateGoogle): Open articles in Google Translate from the native article toolbar with a configurable target language.
+
+### By [@bowencool](https://github.com/bowencool)
+
+* [Broad Site Icon Fetcher](https://github.com/bowencool/xExtension-BroadIconFetcher): Fetch feed icons from RSS/Atom channel images, web manifests, metadata, and common HTML favicon declarations.

--- a/repositories.json
+++ b/repositories.json
@@ -139,4 +139,7 @@
 }, {
 	"url": "https://github.com/profduweb/xExtension-TranslateGoogle",
 	"type": "git"
+}, {
+	"url": "https://github.com/bowencool/xExtension-BroadIconFetcher",
+	"type": "git"
 }]


### PR DESCRIPTION
## Summary

- Register `bowencool/xExtension-BroadIconFetcher` as a third-party extension repository.
- Add the extension to the community list in the README.

## Why

Broad Site Icon Fetcher expands FreshRSS favicon discovery by preferring RSS/Atom channel images, then checking web manifests, metadata, and standard HTML favicon declarations.

## User impact

The repository will be discovered by the generated extension list and can be installed by tools that consume the FreshRSS community repository catalogue.

## Validation

- Confirmed `repositories.json` is valid JSON.
- Confirmed the public repository exposes complete `metadata.json` with version `0.1.2`.
- Tested RSS/Atom channel-image extraction against an RSSHub feed.
