### PR TITLE
Tag Emoji and Telegraaf Premium Tag extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,3 +258,8 @@ There are some FreshRSS extensions out there, developed by community members.
 ### By [@cevvalkoala](https://github.com/cevvalkoala)
 
 * [YouTube Duration](https://github.com/cevvalkoala/xExtension-YouTubeDuration): Add YouTube video duration or Shorts markers to new YouTube entry titles using the YouTube Data API, a local cache and configurable system-wide formatting.
+
+### By [@barrymieny](https://github.com/barrymieny)
+
+* [Tag Emoji](https://github.com/barrymieny/xExtension-TagEmoji): Prefix an entry title with a configured emoji when the entry has a matching feed tag.
+* [Telegraaf Premium Tag](https://github.com/barrymieny/xExtension-TelegraafPremiumTag): Synchronize the #Premium article tag with the unnamespaced `<premium>` field in Telegraaf RSS items.

--- a/repositories.json
+++ b/repositories.json
@@ -145,4 +145,10 @@
 }, {
 	"url": "https://github.com/cevvalkoala/xExtension-YouTubeDuration",
 	"type": "git"
+}, {
+	"url": "https://github.com/barrymieny/xExtension-TagEmoji",
+	"type": "git"
+}, {
+	"url": "https://github.com/barrymieny/xExtension-TelegraafPremiumTag",
+	"type": "git"
 }]


### PR DESCRIPTION
While the Tag Emoji extension is more generally usable, the Telegraaf Premium Tag extension scratches a very specific itch to identify paywalled items on telegraaf.nl