### PR TITLE
+Add extension TagEZ

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,3 +263,7 @@ There are some FreshRSS extensions out there, developed by community members.
 
 * [Tag Emoji](https://github.com/barrymieny/xExtension-TagEmoji): Prefix an entry title with a configured emoji when the entry has a matching feed tag.
 * [Telegraaf Premium Tag](https://github.com/barrymieny/xExtension-TelegraafPremiumTag): Synchronize the #Premium article tag with the unnamespaced `<premium>` field in Telegraaf RSS items.
+
+### By [@Marc-T](https://github.com/Marc-T)
+
+* [TagEZ](https://github.com/Marc-T/xExtension-TagEZ): Adds a Tags accordion to the left sidebar of FreshRSS, listing article tags

--- a/repositories.json
+++ b/repositories.json
@@ -151,4 +151,7 @@
 }, {
 	"url": "https://github.com/barrymieny/xExtension-TelegraafPremiumTag",
 	"type": "git"
+}, {
+	"url": "https://github.com/Marc-T/xExtension-TagEZ",
+	"type": "git"
 }]


### PR DESCRIPTION
## Add TagEZ to third-party extensions

Adds **TagEZ** to `repositories.json` and to the *Third-party extensions* section of the README, as suggested in discussion #512.

**What it does:** TagEZ adds a Tags accordion to the left sidebar of FreshRSS, listing article tags (from feed `<category>` elements, the ones searchable with `#tag`) with their article count, sorted by popularity. Clicking a tag filters the article list, and a button lets users save a tag as a user filter (favorited tags are pinned to the top).

Repo: https://github.com/Marc-T/xExtension-TagEZ

Related discussion: #512

### Changes
- `repositories.json`: added an entry for `Marc-T/xExtension-TagEZ`
- `README.md`: added a new `### By @Marc-T` entry under *Third-party extensions*