### PR TITLE
Add Keyword Auto Read extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,3 +267,7 @@ There are some FreshRSS extensions out there, developed by community members.
 ### By [@Marc-T](https://github.com/Marc-T)
 
 * [TagEZ](https://github.com/Marc-T/xExtension-TagEZ): Adds a Tags accordion to the left sidebar of FreshRSS, listing article tags
+
+### By [@hyprninja](https://github.com/hyprninja)
+
+* [Keyword Auto Read](https://github.com/hyprninja/freshrss-keyword-auto-read): Mark incoming articles as read when they match keyword, field-scoped or regular expression rules, with a dry-run mode and a sweep for articles already stored.

--- a/repositories.json
+++ b/repositories.json
@@ -154,4 +154,7 @@
 }, {
 	"url": "https://github.com/Marc-T/xExtension-TagEZ",
 	"type": "git"
+}, {
+	"url": "https://github.com/hyprninja/freshrss-keyword-auto-read",
+	"type": "git"
 }]


### PR DESCRIPTION
Adds [Keyword Auto Read](https://github.com/hyprninja/freshrss-keyword-auto-read) to `repositories.json` and the README list.

It marks incoming articles as read when they match a keyword rule, so they never reach the unread stream. FreshRSS already does this per feed through filter actions; this applies one rule set across every feed.

- Hooks `entry_before_insert`; rules can be plain keywords, scoped to a single field (`title:`, `content:`, `author:`, `url:`, `tag:`) or full PCRE, with whole-word and case-sensitivity options
- Feed include/exclude lists, a dry-run mode that only logs, and an in-page tester for checking a rule against a sample headline
- An optional sweep that applies the rules to articles already stored, paging through `FreshRSS_EntryDAO::listWhere()` under a time budget; it only ever marks read, never deletes

Written against the 1.29.1 sources. `metadata.json` carries `name`, `author`, `description`, `version`, `entrypoint` and `type`, and the extension lives in `xExtension-KeywordAutoRead/` at the repository root, so `generate.php` should pick it up. Licensed AGPL-3.0.

The repository has a standalone test harness (no FreshRSS or composer needed) that stubs the FreshRSS API, run in CI with `php -l` on every source file across PHP 7.4 to 8.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)